### PR TITLE
Update AFR project generation configuration files (for afr-v202002.00-rx-1.0.2 package)

### DIFF
--- a/vendors/renesas/configuration/CloudKitRX65N_scfg.ftl
+++ b/vendors/renesas/configuration/CloudKitRX65N_scfg.ftl
@@ -1,0 +1,181 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<smc>
+<general version="2.0.0.0">
+<configuration active="true" id="${configurationTypeReleaseID}">
+<property id="com.renesas.smc.service.project.buildArtefactType" values="com.renesas.smc.service.project.buildArtefactType.exe"/>
+<toolchain id="${toolChainID}">
+<option id="com.renesas.smc.toolchain.option.buildArtefactType" key="com.renesas.smc.toolchain.option.buildArtefactType.exe"/>
+<option id="com.renesas.smc.toolchain.option.rtos" key="com.renesas.smc.toolchain.option.rtos.freertos">
+<item id="com.renesas.smc.toolchain.option.rtos.freertos" value="AmazonFreeRTOS_RX_${packageVersion}"/>
+</option>
+</toolchain>
+</configuration>
+<platform id="${targetDevice}"/>
+<option id="board" value="Custom User Board"/>
+</general>
+<tool id="Summary" version="1.0.0.0">
+<option id="com.renesas.smc.code.type" value="Normal Folder"/>
+</tool>
+<tool id="SWComponent" version="1.0.0.0">
+<configuration inuse="true" name="r_bsp">
+<component display="r_bsp" id="r_bsp5.50" version="5.50">
+<gridItem id="BSP_CFG_CODE_FLASH_BANK_MODE" selectedIndex="0"/>
+<gridItem id="BSP_CFG_USER_STACK_ENABLE" selectedIndex="1"/>
+<gridItem id="BSP_CFG_SWINT_UNIT2_ENABLE" selectedIndex="1"/>
+</component>
+<source id="com.renesas.smc.tools.swcomponent.fit.source"/>
+</configuration>
+<configuration inuse="true" name="r_wifi_sx_ulpgn">
+<component description="Dependency : r_bsp version(s) 5.20&#10;Dependency : r_byteq version(s) 1.80&#10;Dependency : r_sci_rx version(s) 3.20&#10;Use UART to control SX-ULPGN and connect to the Internet." detailDescription="WI-FI Module control functions for Renesas MCUs." display="r_wifi_sx_ulpgn" id="r_wifi_sx_ulpgn1.00" version="1.00">
+<gridItem id="WIFI_CFG_SCI_CHANNEL" selectedIndex="0"/>
+<gridItem id="WIFI_CFG_SCI_SECOND_CHANNEL" selectedIndex="1"/>
+<gridItem id="WIFI_CFG_SCI_INTERRUPT_LEVEL" selectedIndex="14"/>
+<gridItem id="WIFI_CFG_SCI_BAUDRATE" selectedIndex="460800"/>
+<gridItem id="WIFI_CFG_SCI_USE_FLOW_CONTROL" selectedIndex="1"/>
+<gridItem id="WIFI_CFG_RESET_PORT" selectedIndex="13"/>
+<gridItem id="WIFI_CFG_RESET_PIN" selectedIndex="0"/>
+<gridItem id="WIFI_CFG_RTS_PORT" selectedIndex="2"/>
+<gridItem id="WIFI_CFG_RTS_PIN" selectedIndex="2"/>
+<gridItem id="WIFI_CFG_CREATABLE_SOCKETS" selectedIndex="4"/>
+<gridItem id="WIFI_CFG_SOCKETS_RECEIVE_BUFFER_SIZE" selectedIndex="8192"/>
+<gridItem id="WIFI_CFG_USE_CALLBACK_FUNCTION" selectedIndex="0"/>
+<gridItem id="WIFI_CFG_CALLBACK_FUNCTION_NAME" selectedIndex="NULL"/>
+</component>
+<source description="Components supporting Firmware Integration Technology" display="Firmware Integration Technology" id="com.renesas.smc.tools.swcomponent.fit.source"/>
+<source description="Components supporting Firmware Integration Technology" display="Firmware Integration Technology" id="com.renesas.smc.tools.swcomponent.fit.source"/>
+</configuration>
+<configuration inuse="true" name="r_s12ad_rx">
+<component display="r_s12ad_rx" id="r_s12ad_rx4.50" version="4.50">
+<gridItem id="S12AD0" selectedIndex="1"/>
+<gridItem id="S12AD0" selectedIndex="0"/>
+</component>
+<source description="Components supporting Firmware Integration Technology" display="Firmware Integration Technology" id="com.renesas.smc.tools.swcomponent.fit.source"/>
+</configuration>
+<configuration inuse="true" name="r_flash_rx">
+<component display="r_flash_rx" id="r_flash_rx4.50" version="4.50">
+<gridItem id="FLASH_CFG_PARAM_CHECKING_ENABLE" selectedIndex="1"/>
+<gridItem id="FLASH_CFG_CODE_FLASH_ENABLE" selectedIndex="1"/>
+<gridItem id="FLASH_CFG_DATA_FLASH_BGO" selectedIndex="1"/>
+<gridItem id="FLASH_CFG_CODE_FLASH_BGO" selectedIndex="1"/>
+<gridItem id="FLASH_CFG_CODE_FLASH_RUN_FROM_ROM" selectedIndex="1"/>
+</component>
+<source description="Components supporting Firmware Integration Technology" display="Firmware Integration Technology" id="com.renesas.smc.tools.swcomponent.fit.source"/>
+</configuration>
+<configuration inuse="true" name="r_sci_rx">
+<component display="r_sci_rx" id="r_sci_rx3.40" version="3.40">
+<gridItem id="SCI_CFG_CH1_INCLUDED" selectedIndex="0"/>
+<gridItem id="SCI_CFG_CH8_INCLUDED" selectedIndex="1"/>
+<gridItem id="RXD0/SMISO0" selectedIndex="1"/>
+<gridItem id="TXD0/SMOSI0" selectedIndex="1"/>
+<gridItem id="CTS0#/RTS0#/SS0#" selectedIndex="1"/>
+<gridItem id="SCI0" selectedIndex="1"/>
+<gridItem id="RXD1/SMISO1" selectedIndex="1"/>
+<gridItem id="TXD1/SMOSI1" selectedIndex="1"/>
+<gridItem id="RXD5/SMISO5" selectedIndex="1"/>
+<gridItem id="TXD5/SMOSI5" selectedIndex="1"/>
+<gridItem id="SCI5" selectedIndex="1"/>
+<gridItem id="RXD8/SMISO8/SSCL8" selectedIndex="0"/>
+<gridItem id="TXD8/SMOSI8/SSDA8" selectedIndex="0"/>
+<gridItem id="SCI8" selectedIndex="0"/>
+<gridItem id="SCI_CFG_CH0_INCLUDED" selectedIndex="1"/>
+<gridItem id="SCI_CFG_CH1_INCLUDED" selectedIndex="1"/>
+<gridItem id="SCI_CFG_CH5_INCLUDED" selectedIndex="1"/>
+<gridItem id="SCI_CFG_CH8_INCLUDED" selectedIndex="0"/>
+<gridItem id="SCI_CFG_CH0_TX_BUFSIZ" selectedIndex="2180"/>
+<gridItem id="SCI_CFG_CH1_TX_BUFSIZ" selectedIndex="2180"/>
+<gridItem id="SCI_CFG_CH1_RX_BUFSIZ" selectedIndex="4096"/>
+<gridItem id="SCI_CFG_CH2_RX_BUFSIZ" selectedIndex="4096"/>
+</component>
+<source description="Components supporting Firmware Integration Technology" display="Firmware Integration Technology" id="com.renesas.smc.tools.swcomponent.fit.source"/>
+</configuration>
+<configuration inuse="true" name="r_byteq">
+<component display="r_byteq" id="r_byteq1.80" version="1.80"/>
+<source description="Components supporting Firmware Integration Technology" display="Firmware Integration Technology" id="com.renesas.smc.tools.swcomponent.fit.source"/>
+</configuration>
+<configuration inuse="true" name="FreeRTOS_Object">
+<component display="FreeRTOS_Object" id="com.renesas.smc.tools.swcomponent.rtosconfigurator.freertos.object"/>
+<source id="com.renesas.smc.tools.swcomponent.rtosconfigurator.source"/>
+</configuration>
+<configuration inuse="true" name="FreeRTOS_Kernel">
+<component display="FreeRTOS_Kernel" id="com.renesas.smc.tools.swcomponent.rtosconfigurator.freertos.amazon.kernel">
+<gridItem id="configTOTAL_HEAP_SIZE" selectedIndex="( size_t ) ( 256U * 1024U )"/>
+</component>
+<source id="com.renesas.smc.tools.swcomponent.rtosconfigurator.source"/>
+</configuration>
+<configuration inuse="true" name="AWS_device_shadow">
+<component display="AWS_device_shadow" id="com.renesas.smc.tools.swcomponent.rtosconfigurator.freertos.amazon.device_shadow"/>
+<source id="com.renesas.smc.tools.swcomponent.rtosconfigurator.source"/>
+</configuration>
+<configuration inuse="true" name="AWS_tcp_ip">
+<component display="AWS_tcp_ip" id="com.renesas.smc.tools.swcomponent.rtosconfigurator.freertos.amazon.tcp_ip">
+<gridItem id="ipconfigINCLUDE_FULL_INET_ADDR" selectedIndex="0"/>
+<gridItem id="ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS" selectedIndex="8"/>
+<gridItem id="ipconfigUSE_TCP_WIN" selectedIndex="0"/>
+</component>
+<source id="com.renesas.smc.tools.swcomponent.rtosconfigurator.source"/>
+</configuration>
+<configuration inuse="true" name="AWS_mqtt">
+<component display="AWS_mqtt" id="com.renesas.smc.tools.swcomponent.rtosconfigurator.freertos.amazon.mqtt">
+<gridItem id="mqttconfigMQTT_TASK_STACK_DEPTH" selectedIndex="6114"/>
+</component>
+<source id="com.renesas.smc.tools.swcomponent.rtosconfigurator.source"/>
+</configuration>
+<configuration inuse="true" name="AWS_secure_socket">
+<component display="AWS_secure_socket" id="com.renesas.smc.tools.swcomponent.rtosconfigurator.freertos.amazon.secure_socket"/>
+<source id="com.renesas.smc.tools.swcomponent.rtosconfigurator.source"/>
+</configuration>
+<configuration inuse="true" name="AWS_ggd">
+<component display="AWS_ggd" id="com.renesas.smc.tools.swcomponent.rtosconfigurator.freertos.amazon.ggd"/>
+<source id="com.renesas.smc.tools.swcomponent.rtosconfigurator.source"/>
+</configuration>
+</tool>
+<tool id="Clock">
+<option enabled="true" id="mainclockenable" selection="uncheck">
+</option>
+<option enabled="false" id="mainsourcebox" selection="srcR">
+</option>
+<option enabled="false" id="mainfrequency" selection="textinputitem">
+</option>
+<option enabled="false" id="mainwaittime" selection="textinputitem">
+</option>
+<option enabled="true" id="hococlockenable" selection="check">
+</option>
+<option enabled="true" id="hocofrequency" selection="frq20">
+</option>
+<option enabled="true" id="hocooscenable" selection="uncheck">
+</option>
+<option enabled="true" id="pllswitcher" selection="pllhoco">
+<item enabled="false" id="pllmain" input="" value="24.0"/>
+<item enabled="true" id="pllhoco" input="" value="20"/>
+</option>
+<option enabled="true" id="plldivider" selection="div1-1">
+<item enabled="true" id="div1-1"/>
+<item enabled="true" id="div1-2"/>
+<item enabled="false" id="div1-3"/>
+</option>
+<option enabled="true" id="pllmul" selection="mul12-1">
+<item enabled="true" id="mul10_5-1"/>
+<item enabled="true" id="mul11-1"/>
+<item enabled="true" id="mul11_5-1"/>
+<item enabled="true" id="mul12-1"/>
+</option>
+<option enabled="true" id="sckswitcher" selection="pll">
+<item enabled="false" id="main" input="" value="2.4E7"/>
+<item enabled="true" id="hoco" input="" value="20000000"/>
+</option>
+<option enabled="true" id="uclk" selection="textoutputitem">
+<item enabled="false" id="textoutputitem" input="" value="48.0"/>
+</option>
+<option enabled="true" id="cachclk" selection="textoutputitem">
+<item enabled="true" id="textoutputitem" input="" value="20"/>
+</option>
+<option enabled="false" id="cacmclk" selection="textoutputitem">
+<item enabled="true" id="textoutputitem" input="" value="24.0"/>
+</option>
+<Item current="true" id="uckdivider.selectBox"/>
+<Item current="240.0 MHz" id="uckdivider.InputValue"/>
+<Item current="48.0 MHz" id="uckdivider.OutputValue"/>
+<Item current="sckselector.radiobutton.swtpll" id="uckdivider.Condition"/>
+<Item current="comboBox1-5" error="false" id="uckdivider.comboBox"/>
+</tool>
+</smc>

--- a/vendors/renesas/configuration/EnvisionRX72N_scfg.ftl
+++ b/vendors/renesas/configuration/EnvisionRX72N_scfg.ftl
@@ -1,0 +1,213 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<smc>
+<general version="2.0.0.0">
+<configuration active="true" id="${configurationTypeReleaseID}">
+<property id="com.renesas.smc.service.project.buildArtefactType" values="com.renesas.smc.service.project.buildArtefactType.exe"/>
+<toolchain id="${toolChainID}">
+<option id="com.renesas.smc.toolchain.option.buildArtefactType" key="com.renesas.smc.toolchain.option.buildArtefactType.exe"/>
+<option id="com.renesas.smc.toolchain.option.rtos" key="com.renesas.smc.toolchain.option.rtos.freertos">
+<item id="com.renesas.smc.toolchain.option.rtos.freertos" value="AmazonFreeRTOS_RX_${packageVersion}"/>
+</option>
+</toolchain>
+</configuration>
+<platform id="${targetDevice}"/>
+<option id="board" value="Custom User Board"/>
+</general>
+<tool id="Summary" version="1.0.0.0">
+<option id="com.renesas.smc.code.type" value="Normal Folder"/>
+</tool>
+<tool id="SWComponent" version="1.0.0.0">
+<configuration inuse="true" name="r_bsp">
+<component display="r_bsp" id="r_bsp5.50" version="5.50">
+<gridItem id="BSP_CFG_USER_STACK_ENABLE" selectedIndex="0"/>
+<gridItem id="BSP_CFG_ISTACK_BYTES" selectedIndex="0x1000"/>
+<gridItem id="BSP_CFG_HEAP_BYTES" selectedIndex="0x1000"/>
+<gridItem id="BSP_CFG_CODE_FLASH_BANK_MODE" selectedIndex="0"/>
+<gridItem id="BSP_CFG_SWINT_UNIT2_ENABLE" selectedIndex="0"/>
+<gridItem id="BSP_CFG_ROM_CACHE_ENABLE" selectedIndex="0"/>
+</component>
+<source id="com.renesas.smc.tools.swcomponent.fit.source"/>
+</configuration>
+<configuration inuse="true" name="r_s12ad_rx">
+<component display="r_s12ad_rx" id="r_s12ad_rx4.50" version="4.50"></component>
+<source description="Components supporting Firmware Integration Technology" display="Firmware Integration Technology" id="com.renesas.smc.tools.swcomponent.fit.source"/>
+</configuration>
+<configuration inuse="true" name="r_flash_rx">
+<component display="r_flash_rx" id="r_flash_rx4.50" version="4.50">
+<gridItem id="FLASH_CFG_PARAM_CHECKING_ENABLE" selectedIndex="1"/>
+<gridItem id="FLASH_CFG_CODE_FLASH_ENABLE" selectedIndex="1"/>
+<gridItem id="FLASH_CFG_DATA_FLASH_BGO" selectedIndex="1"/>
+<gridItem id="FLASH_CFG_CODE_FLASH_BGO" selectedIndex="1"/>
+<gridItem id="FLASH_CFG_CODE_FLASH_RUN_FROM_ROM" selectedIndex="1"/>
+</component>
+<source description="Components supporting Firmware Integration Technology" display="Firmware Integration Technology" id="com.renesas.smc.tools.swcomponent.fit.source"/>
+</configuration>
+<configuration inuse="true" name="r_sci_rx">
+<component display="r_sci_rx" id="r_sci_rx3.40" version="3.40">
+<gridItem id="RXD2/SMISO2" selectedIndex="1"/>
+<gridItem id="TXD2/SMOSI2" selectedIndex="1"/>
+<gridItem id="SCI2" selectedIndex="1"/>
+<gridItem id="RXD7/SMISO7" selectedIndex="1"/>
+<gridItem id="TXD7/SMOSI7" selectedIndex="1"/>
+<gridItem id="SCI7" selectedIndex="1"/>
+<gridItem id="SCI_CFG_TEI_INCLUDED" selectedIndex="1"/>
+<gridItem id="SCI_CFG_CH2_INCLUDED" selectedIndex="1"/>
+<gridItem id="SCI_CFG_CH7_INCLUDED" selectedIndex="1"/>
+<gridItem id="SCI_CFG_CH1_INCLUDED" selectedIndex="0"/>
+</component>
+<source description="Components supporting Firmware Integration Technology" display="Firmware Integration Technology" id="com.renesas.smc.tools.swcomponent.fit.source"/>
+</configuration>
+<configuration inuse="true" name="r_byteq">
+<component display="r_byteq" id="r_byteq1.80" version="1.80"></component>
+<source description="Components supporting Firmware Integration Technology" display="Firmware Integration Technology" id="com.renesas.smc.tools.swcomponent.fit.source"/>
+</configuration>
+<configuration inuse="true" name="r_ether_rx">
+<component display="r_ether_rx" id="r_ether_rx1.20" version="1.20">
+<gridItem id="CLKOUT25M" selectedIndex="1"/>
+<gridItem id="ET0_TX_CLK" selectedIndex="1"/>
+<gridItem id="ET0_RX_CLK" selectedIndex="1"/>
+<gridItem id="ET0_TX_EN" selectedIndex="1"/>
+<gridItem id="ET0_ETXD3" selectedIndex="1"/>
+<gridItem id="ET0_ETXD2" selectedIndex="1"/>
+<gridItem id="ET0_ETXD1" selectedIndex="1"/>
+<gridItem id="ET0_ETXD0" selectedIndex="1"/>
+<gridItem id="ET0_TX_ER" selectedIndex="1"/>
+<gridItem id="ET0_RX_DV" selectedIndex="1"/>
+<gridItem id="ET0_ERXD3" selectedIndex="1"/>
+<gridItem id="ET0_ERXD2" selectedIndex="1"/>
+<gridItem id="ET0_ERXD1" selectedIndex="1"/>
+<gridItem id="ET0_ERXD0" selectedIndex="1"/>
+<gridItem id="ET0_RX_ER" selectedIndex="1"/>
+<gridItem id="ET0_CRS" selectedIndex="1"/>
+<gridItem id="ET0_COL" selectedIndex="1"/>
+<gridItem id="ET0_MDC" selectedIndex="1"/>
+<gridItem id="ET0_MDIO" selectedIndex="1"/>
+<gridItem id="ET0_MDC" selectedIndex="1"/>
+<gridItem id="ET0_MDIO" selectedIndex="1"/>
+<gridItem id="CLKOUT25M" selectedIndex="1"/>
+<gridItem id="ETHERC0_MII" selectedIndex="1"/>
+<gridItem id="ETHER_CFG_CH0_PHY_ACCESS" selectedIndex="0"/>
+<gridItem id="ETHER_CFG_CH1_PHY_ACCESS" selectedIndex="0"/>
+<gridItem id="ETHER_CFG_USE_LINKSTA" selectedIndex="0"/>
+<gridItem id="ETHER_CFG_CH0_PHY_ADDRESS" selectedIndex="0"/>
+<gridItem id="ETHER_CFG_CH1_PHY_ADDRESS" selectedIndex="1"/>
+<gridItem id="ETHER_CFG_EMAC_RX_DESCRIPTORS" selectedIndex="4"/>
+<gridItem id="ETHER_CFG_EMAC_TX_DESCRIPTORS" selectedIndex="4"/>
+<gridItem id="ETHER_CFG_BUFSIZE" selectedIndex="1536"/>
+<gridItem id="ETHER_CFG_AL1_INT_PRIORTY" selectedIndex="13"/>
+<gridItem id="ETHER_CFG_CH1_PHY_ACCESS" selectedIndex="1"/>
+<gridItem id="ETHER_CFG_USE_PHY_KSZ8041NL" selectedIndex="1"/>
+</component>
+<source description="Components supporting Firmware Integration Technology" display="Firmware Integration Technology" id="com.renesas.smc.tools.swcomponent.fit.source"/>
+</configuration>
+<configuration inuse="true" name="FreeRTOS_Object">
+<component display="FreeRTOS_Object" id="com.renesas.smc.tools.swcomponent.rtosconfigurator.freertos.object"/>
+<source id="com.renesas.smc.tools.swcomponent.rtosconfigurator.source"/>
+</configuration>
+<configuration inuse="true" name="FreeRTOS_Kernel">
+<component display="FreeRTOS_Kernel" id="com.renesas.smc.tools.swcomponent.rtosconfigurator.freertos.amazon.kernel">
+<gridItem id="configTOTAL_HEAP_SIZE" selectedIndex="( size_t ) ( 256U * 1024U )"/>
+</component>
+<source id="com.renesas.smc.tools.swcomponent.rtosconfigurator.source"/>
+</configuration>
+<configuration inuse="true" name="AWS_device_shadow">
+<component display="AWS_device_shadow" id="com.renesas.smc.tools.swcomponent.rtosconfigurator.freertos.amazon.device_shadow"/>
+<source id="com.renesas.smc.tools.swcomponent.rtosconfigurator.source"/>
+</configuration>
+<configuration inuse="true" name="AWS_tcp_ip">
+<component display="AWS_tcp_ip" id="com.renesas.smc.tools.swcomponent.rtosconfigurator.freertos.amazon.tcp_ip">
+<gridItem id="ipconfigINCLUDE_FULL_INET_ADDR" selectedIndex="0"/>
+<gridItem id="ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS" selectedIndex="8"/>
+<gridItem id="ipconfigUSE_TCP_WIN" selectedIndex="0"/>
+</component>
+<source id="com.renesas.smc.tools.swcomponent.rtosconfigurator.source"/>
+</configuration>
+<configuration inuse="true" name="AWS_mqtt">
+<component display="AWS_mqtt" id="com.renesas.smc.tools.swcomponent.rtosconfigurator.freertos.amazon.mqtt">
+<gridItem id="mqttconfigMQTT_TASK_STACK_DEPTH" selectedIndex="6114"/>
+</component>
+<source id="com.renesas.smc.tools.swcomponent.rtosconfigurator.source"/>
+</configuration>
+<configuration inuse="true" name="AWS_secure_socket">
+<component display="AWS_secure_socket" id="com.renesas.smc.tools.swcomponent.rtosconfigurator.freertos.amazon.secure_socket"/>
+<source id="com.renesas.smc.tools.swcomponent.rtosconfigurator.source"/>
+</configuration>
+<configuration inuse="true" name="AWS_ggd">
+<component display="AWS_ggd" id="com.renesas.smc.tools.swcomponent.rtosconfigurator.freertos.amazon.ggd"/>
+<source id="com.renesas.smc.tools.swcomponent.rtosconfigurator.source"/>
+</configuration>
+</tool>
+<tool id="Clock">
+<Item current="16 MHz" id="mainclock.OutputValue"/>
+<Item current="16" error="false" id="mainclock.frequencyTxt"/>
+<Item current="16 MHz" id="pllSourceSelect.InputValue"/>
+<Item current="16 MHz" id="pllSourceSelect.OutputValue"/>
+<Item current="16 MHz" id="pll.InputValue"/>
+<Item current="mul15-1" error="false" id="pll.multiplyBox"/>
+<Item current="16.0 MHz" error="false" id="pll.MiddleValue"/>
+<Item current="16 MHz" id="ppll.InputValue"/>
+<Item current="mul12_5-1" error="false" id="ppll.multiplyBox"/>
+<Item current="div1-1" error="false" id="ppll.dividerBox"/>
+<Item current="16.0 MHz" error="false" id="ppll.MiddleValue"/>
+<Item current="16 MHz" id="ckoselector.InputValue"/>
+<Item current="16 MHz" id="ckoselector.OutputValue"/>
+<Item current="16 MHz" id="ckodivider.InputValue"/>
+<Item current="16.0 MHz" id="ckodivider.OutputValue"/>
+<Item current="16 MHz" error="false" id="ckodivider.PreOutput"/>
+<Item current="120.0 MHz" id="bck.InputValue"/>
+<Item current="120.0 MHz" id="bck.OutputValue"/>
+<Item current="120.0" id="bck.frequencyTxt"/>
+<Item current="120.0" id="bck.CurrentValue"/>
+<Item current="120.0 MHz" id="sdclk.InputValue"/>
+<Item current="true" id="sdclk.SelectBoxDisabled"/>
+<Item current="16.0 MHz" id="clkout.InputValue"/>
+<Item current="16.0" id="clkout.CurrentValue"/>
+<Item current="16 MHz" id="cacmclk.InputValue"/>
+<Item current="16 MHz" id="cacmclk.OutputValue"/>
+<Item current="16" id="cacmclk.frequencyTxt"/>
+<Item current="16" id="cacmclk.CurrentValue"/>
+<Item current="true" id="bckdivider.isSelected"/>
+<Item current="240.0 MHz" id="bckdivider.InputValue"/>
+<Item current="120.0 MHz" id="bckdivider.OutputValue"/>
+<Item current="sckselector.radiobutton.swtpll" id="bckdivider.Condition"/>
+<Item current="comboBox1-2" error="false" id="bckdivider.comboBox"/>
+<Item current="240.0 MHz" error="false" id="bckdivider.PreOutput"/>
+<Item current="iclkdivider" error="false" id="bckdivider.PreOutputController"/>
+<Item current="false" id="bckselector.selectBox"/>
+<Item current="120.0 MHz" id="bckselector.InputValue"/>
+<Item current="" id="bckselector.OutputValue"/>
+<Item current="comboBox1-2" error="false" id="bckselector.comboBox"/>
+<Item current="true" id="uckdivider.selectBox"/>
+<Item current="240.0 MHz" id="uckdivider.InputValue"/>
+<Item current="48.0 MHz" id="uckdivider.OutputValue"/>
+<Item current="sckselector.radiobutton.swtpll" id="uckdivider.Condition"/>
+<Item current="comboBox1-5" error="false" id="uckdivider.comboBox"/>
+</tool>
+<tool id="Pins" version="1.0.1.0">
+<pinItem allocation="128" comments="" direction="None" id="RXD7" isUsedBySoftware="false" locked="false" status="0"/>
+<pinItem allocation="131" comments="" direction="None" id="TXD7" isUsedBySoftware="false" locked="false" status="0"/>
+<pinItem allocation="45" comments="" direction="None" id="RXD2" isUsedBySoftware="false" locked="false" status="0"/>
+<pinItem allocation="44" comments="" direction="None" id="TXD2" isUsedBySoftware="false" locked="false" status="0"/>
+<pinItem allocation="68" comments="" direction="None" id="ET0_RX_ER" isUsedBySoftware="false" locked="false" status="0"/>
+<pinItem allocation="61" comments="" direction="None" id="ET0_ETXD3" isUsedBySoftware="false" locked="false" status="0"/>
+<pinItem allocation="62" comments="" direction="None" id="ET0_ETXD2" isUsedBySoftware="false" locked="false" status="0"/>
+<pinItem allocation="63" comments="" direction="None" id="ET0_ETXD1" isUsedBySoftware="false" locked="false" status="0"/>
+<pinItem allocation="64" comments="" direction="None" id="ET0_ETXD0" isUsedBySoftware="false" locked="false" status="0"/>
+<pinItem allocation="69" comments="" direction="None" id="ET0_RX_CLK" isUsedBySoftware="false" locked="false" status="0"/>
+<pinItem allocation="75" comments="" direction="None" id="ET0_ERXD3" isUsedBySoftware="false" locked="false" status="0"/>
+<pinItem allocation="73" comments="" direction="None" id="ET0_ERXD2" isUsedBySoftware="false" locked="false" status="0"/>
+<pinItem allocation="72" comments="" direction="None" id="ET0_ERXD1" isUsedBySoftware="false" locked="false" status="0"/>
+<pinItem allocation="71" comments="" direction="None" id="ET0_ERXD0" isUsedBySoftware="false" locked="false" status="0"/>
+<pinItem allocation="66" comments="" direction="None" id="ET0_TX_CLK" isUsedBySoftware="false" locked="false" status="0"/>
+<pinItem allocation="86" comments="" direction="None" id="ET0_MDIO" isUsedBySoftware="false" locked="false" status="0"/>
+<pinItem allocation="50" comments="" direction="None" id="CLKOUT25M" isUsedBySoftware="true" locked="false" status="0"/>
+<pinItem allocation="20" comments="" direction="None" id="XTAL" isUsedBySoftware="true" locked="false" status="0"/>
+<pinItem allocation="65" comments="" direction="None" id="ET0_TX_EN" isUsedBySoftware="false" locked="false" status="0"/>
+<pinItem allocation="67" comments="" direction="None" id="ET0_TX_ER" isUsedBySoftware="false" locked="false" status="0"/>
+<pinItem allocation="85" comments="" direction="None" id="ET0_MDC" isUsedBySoftware="false" locked="false" status="0"/>
+<pinItem allocation="60" comments="" direction="None" id="ET0_COL" isUsedBySoftware="false" locked="false" status="0"/>
+<pinItem allocation="58" comments="" direction="None" id="ET0_CRS" isUsedBySoftware="false" locked="false" status="0"/>
+<pinItem allocation="22" comments="" direction="None" id="EXTAL" isUsedBySoftware="true" locked="false" status="0"/>
+<pinItem allocation="70" comments="" direction="None" id="ET0_RX_DV" isUsedBySoftware="false" locked="false" status="0"/>
+</tool>
+</smc>

--- a/vendors/renesas/configuration/RSKRX65N_scfg.ftl
+++ b/vendors/renesas/configuration/RSKRX65N_scfg.ftl
@@ -1,0 +1,166 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<smc>
+<general version="2.0.0.0">
+<configuration active="true" id="${configurationTypeReleaseID}">
+<property id="com.renesas.smc.service.project.buildArtefactType" values="com.renesas.smc.service.project.buildArtefactType.exe"/>
+<toolchain id="${toolChainID}">
+<option id="com.renesas.smc.toolchain.option.buildArtefactType" key="com.renesas.smc.toolchain.option.buildArtefactType.exe"/>
+<option id="com.renesas.smc.toolchain.option.rtos" key="com.renesas.smc.toolchain.option.rtos.freertos">
+<item id="com.renesas.smc.toolchain.option.rtos.freertos" value="AmazonFreeRTOS_RX_${packageVersion}"/>
+</option>
+</toolchain>
+</configuration>
+<platform id="${targetDevice}"/>
+<option id="board" value="Custom User Board"/>
+</general>
+<tool id="Summary" version="1.0.0.0">
+<option id="com.renesas.smc.code.type" value="Normal Folder"/>
+</tool>
+<tool id="SWComponent" version="1.0.0.0">
+<configuration inuse="true" name="r_bsp">
+<component display="r_bsp" id="r_bsp5.50" version="5.50">
+<gridItem id="BSP_CFG_CODE_FLASH_BANK_MODE" selectedIndex="0"/>
+<gridItem id="BSP_CFG_USER_STACK_ENABLE" selectedIndex="1"/>
+<gridItem id="BSP_CFG_SWINT_UNIT2_ENABLE" selectedIndex="1"/>
+</component>
+<source id="com.renesas.smc.tools.swcomponent.fit.source"/>
+</configuration>
+<configuration inuse="true" name="r_s12ad_rx">
+<component display="r_s12ad_rx" id="r_s12ad_rx4.50" version="4.50">
+<gridItem id="S12AD0" selectedIndex="1"/>
+</component>
+<source description="Components supporting Firmware Integration Technology" display="Firmware Integration Technology" id="com.renesas.smc.tools.swcomponent.fit.source"/>
+</configuration>
+<configuration inuse="true" name="r_flash_rx">
+<component display="r_flash_rx" id="r_flash_rx4.50" version="4.50">
+<gridItem id="FLASH_CFG_PARAM_CHECKING_ENABLE" selectedIndex="1"/>
+<gridItem id="FLASH_CFG_CODE_FLASH_ENABLE" selectedIndex="1"/>
+<gridItem id="FLASH_CFG_DATA_FLASH_BGO" selectedIndex="1"/>
+<gridItem id="FLASH_CFG_CODE_FLASH_BGO" selectedIndex="1"/>
+<gridItem id="FLASH_CFG_CODE_FLASH_RUN_FROM_ROM" selectedIndex="1"/>
+</component>
+<source description="Components supporting Firmware Integration Technology" display="Firmware Integration Technology" id="com.renesas.smc.tools.swcomponent.fit.source"/>
+</configuration>
+<configuration inuse="true" name="r_sci_rx">
+<component display="r_sci_rx" id="r_sci_rx3.40" version="3.40">
+<gridItem id="SCI_CFG_CH1_INCLUDED" selectedIndex="0"/>
+<gridItem id="SCI_CFG_CH8_INCLUDED" selectedIndex="1"/>
+<gridItem id="SCK1" selectedIndex="1"/>
+<gridItem id="SCI1" selectedIndex="1"/>
+<gridItem id="SCK6" selectedIndex="1"/>
+<gridItem id="SCI6" selectedIndex="1"/>
+<gridItem id="RXD8/SMISO8/SSCL8" selectedIndex="1"/>
+<gridItem id="TXD8/SMOSI8/SSDA8" selectedIndex="1"/>
+<gridItem id="SCI8" selectedIndex="1"/>
+<gridItem id="SCI_CFG_TEI_INCLUDED" selectedIndex="1"/>
+</component>
+<source description="Components supporting Firmware Integration Technology" display="Firmware Integration Technology" id="com.renesas.smc.tools.swcomponent.fit.source"/>
+</configuration>
+<configuration inuse="true" name="r_byteq">
+<component display="r_byteq" id="r_byteq1.80" version="1.80"/>
+<source description="Components supporting Firmware Integration Technology" display="Firmware Integration Technology" id="com.renesas.smc.tools.swcomponent.fit.source"/>
+</configuration>
+<configuration inuse="true" name="r_ether_rx">
+<component display="r_ether_rx" id="r_ether_rx1.20" version="1.20">
+<gridItem id="ETHER_CFG_CH0_PHY_ACCESS" selectedIndex="0"/>
+<gridItem id="ETHER_CFG_CH1_PHY_ACCESS" selectedIndex="1"/>
+<gridItem id="ETHER_CFG_CH0_PHY_ADDRESS" selectedIndex="30"/>
+<gridItem id="ETHER_CFG_CH1_PHY_ADDRESS" selectedIndex="1"/>
+<gridItem id="ETHER_CFG_EMAC_RX_DESCRIPTORS" selectedIndex="6"/>
+<gridItem id="ETHER_CFG_EMAC_TX_DESCRIPTORS" selectedIndex="3"/>
+<gridItem id="ET0_TX_CLK" selectedIndex="1"/>
+<gridItem id="ET0_RX_CLK" selectedIndex="1"/>
+<gridItem id="ET0_TX_EN" selectedIndex="1"/>
+<gridItem id="ET0_ETXD3" selectedIndex="1"/>
+<gridItem id="ET0_ETXD2" selectedIndex="1"/>
+<gridItem id="ET0_ETXD1" selectedIndex="1"/>
+<gridItem id="ET0_ETXD0" selectedIndex="1"/>
+<gridItem id="ET0_TX_ER" selectedIndex="1"/>
+<gridItem id="ET0_RX_DV" selectedIndex="1"/>
+<gridItem id="ET0_ERXD3" selectedIndex="1"/>
+<gridItem id="ET0_ERXD2" selectedIndex="1"/>
+<gridItem id="ET0_ERXD1" selectedIndex="1"/>
+<gridItem id="ET0_ERXD0" selectedIndex="1"/>
+<gridItem id="ET0_RX_ER" selectedIndex="1"/>
+<gridItem id="ET0_CRS" selectedIndex="1"/>
+<gridItem id="ET0_COL" selectedIndex="1"/>
+<gridItem id="ET0_MDC" selectedIndex="1"/>
+<gridItem id="ET0_MDIO" selectedIndex="1"/>
+<gridItem id="ET0_LINKSTA" selectedIndex="1"/>
+<gridItem id="ETHERC0_MII" selectedIndex="1"/>
+<gridItem id="ET0_MDC" selectedIndex="1"/>
+<gridItem id="ET0_MDIO" selectedIndex="1"/>
+<gridItem id="ET0_LINKSTA" selectedIndex="1"/>
+</component>
+<source description="Components supporting Firmware Integration Technology" display="Firmware Integration Technology" id="com.renesas.smc.tools.swcomponent.fit.source"/>
+</configuration>
+<configuration inuse="true" name="FreeRTOS_Object">
+<component display="FreeRTOS_Object" id="com.renesas.smc.tools.swcomponent.rtosconfigurator.freertos.object"/>
+<source id="com.renesas.smc.tools.swcomponent.rtosconfigurator.source"/>
+</configuration>
+<configuration inuse="true" name="FreeRTOS_Kernel">
+<component display="FreeRTOS_Kernel" id="com.renesas.smc.tools.swcomponent.rtosconfigurator.freertos.amazon.kernel">
+<gridItem id="configTOTAL_HEAP_SIZE" selectedIndex="( size_t ) ( 256U * 1024U )"/>
+</component>
+<source id="com.renesas.smc.tools.swcomponent.rtosconfigurator.source"/>
+</configuration>
+<configuration inuse="true" name="AWS_device_shadow">
+<component display="AWS_device_shadow" id="com.renesas.smc.tools.swcomponent.rtosconfigurator.freertos.amazon.device_shadow"/>
+<source id="com.renesas.smc.tools.swcomponent.rtosconfigurator.source"/>
+</configuration>
+<configuration inuse="true" name="AWS_tcp_ip">
+<component display="AWS_tcp_ip" id="com.renesas.smc.tools.swcomponent.rtosconfigurator.freertos.amazon.tcp_ip">
+<gridItem id="ipconfigINCLUDE_FULL_INET_ADDR" selectedIndex="0"/>
+<gridItem id="ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS" selectedIndex="8"/>
+<gridItem id="ipconfigUSE_TCP_WIN" selectedIndex="0"/>
+</component>
+<source id="com.renesas.smc.tools.swcomponent.rtosconfigurator.source"/>
+</configuration>
+<configuration inuse="true" name="AWS_mqtt">
+<component display="AWS_mqtt" id="com.renesas.smc.tools.swcomponent.rtosconfigurator.freertos.amazon.mqtt">
+<gridItem id="mqttconfigMQTT_TASK_STACK_DEPTH" selectedIndex="6114"/>
+</component>
+<source id="com.renesas.smc.tools.swcomponent.rtosconfigurator.source"/>
+</configuration>
+<configuration inuse="true" name="AWS_secure_socket">
+<component display="AWS_secure_socket" id="com.renesas.smc.tools.swcomponent.rtosconfigurator.freertos.amazon.secure_socket"/>
+<source id="com.renesas.smc.tools.swcomponent.rtosconfigurator.source"/>
+</configuration>
+<configuration inuse="true" name="AWS_ggd">
+<component display="AWS_ggd" id="com.renesas.smc.tools.swcomponent.rtosconfigurator.freertos.amazon.ggd"/>
+<source id="com.renesas.smc.tools.swcomponent.rtosconfigurator.source"/>
+</configuration>
+</tool>
+<tool id="Clock">
+<Item current="true" id="uckdivider.selectBox"/>
+<Item current="240.0 MHz" id="uckdivider.InputValue"/>
+<Item current="48.0 MHz" id="uckdivider.OutputValue"/>
+<Item current="sckselector.radiobutton.swtpll" id="uckdivider.Condition"/>
+<Item current="comboBox1-5" error="false" id="uckdivider.comboBox"/>
+</tool>
+    <tool id="Pins" version="1.0.1.0">
+<pinItem allocation="22" comments="" direction="None" id="XTAL" isUsedBySoftware="true" locked="false" status="0"/>
+<pinItem allocation="59" comments="" direction="None" id="RXD8" isUsedBySoftware="true" locked="false" status="0"/>
+<pinItem allocation="81" comments="" direction="None" id="ET0_TX_EN" isUsedBySoftware="true" locked="false" status="0"/>
+<pinItem allocation="83" comments="" direction="None" id="ET0_TX_ER" isUsedBySoftware="true" locked="false" status="0"/>
+<pinItem allocation="101" comments="" direction="None" id="ET0_MDC" isUsedBySoftware="true" locked="false" status="0"/>
+<pinItem allocation="76" comments="" direction="None" id="ET0_COL" isUsedBySoftware="true" locked="false" status="0"/>
+<pinItem allocation="74" comments="" direction="None" id="ET0_CRS" isUsedBySoftware="true" locked="false" status="0"/>
+<pinItem allocation="58" comments="" direction="None" id="TXD8" isUsedBySoftware="true" locked="false" status="0"/>
+<pinItem allocation="24" comments="" direction="None" id="EXTAL" isUsedBySoftware="true" locked="false" status="0"/>
+<pinItem allocation="86" comments="" direction="None" id="ET0_RX_DV" isUsedBySoftware="true" locked="false" status="0"/>
+<pinItem allocation="27" comments="" direction="None" id="ET0_LINKSTA" isUsedBySoftware="true" locked="false" status="0"/>
+<pinItem allocation="84" comments="" direction="None" id="ET0_RX_ER" isUsedBySoftware="true" locked="false" status="0"/>
+<pinItem allocation="77" comments="" direction="None" id="ET0_ETXD3" isUsedBySoftware="true" locked="false" status="0"/>
+<pinItem allocation="78" comments="" direction="None" id="ET0_ETXD2" isUsedBySoftware="true" locked="false" status="0"/>
+<pinItem allocation="79" comments="" direction="None" id="ET0_ETXD1" isUsedBySoftware="true" locked="false" status="0"/>
+<pinItem allocation="80" comments="" direction="None" id="ET0_ETXD0" isUsedBySoftware="true" locked="false" status="0"/>
+<pinItem allocation="85" comments="" direction="None" id="ET0_RX_CLK" isUsedBySoftware="true" locked="false" status="0"/>
+<pinItem allocation="91" comments="" direction="None" id="ET0_ERXD3" isUsedBySoftware="true" locked="false" status="0"/>
+<pinItem allocation="89" comments="" direction="None" id="ET0_ERXD2" isUsedBySoftware="true" locked="false" status="0"/>
+<pinItem allocation="88" comments="" direction="None" id="ET0_ERXD1" isUsedBySoftware="true" locked="false" status="0"/>
+<pinItem allocation="87" comments="" direction="None" id="ET0_ERXD0" isUsedBySoftware="true" locked="false" status="0"/>
+<pinItem allocation="82" comments="" direction="None" id="ET0_TX_CLK" isUsedBySoftware="true" locked="false" status="0"/>
+<pinItem allocation="102" comments="" direction="None" id="ET0_MDIO" isUsedBySoftware="true" locked="false" status="0"/>
+</tool>
+</smc>

--- a/vendors/renesas/configuration/afr-v202002.00-rx-1.0.2.xml
+++ b/vendors/renesas/configuration/afr-v202002.00-rx-1.0.2.xml
@@ -11,44 +11,36 @@
     <product>GNURX</product>
     <version>4.8.4</version>
   </toolchain>
-  <toolchain>
-    <brand>GNU</brand>
-    <product>GNUARM</product>
-    <version>6.3.1</version>
-  </toolchain>
   <!-- only one target entry allowed; multiple sub tags permitted -->
+<memoryreq>
+    <RAM>256</RAM>
+</memoryreq>
   <target>
     <toolchain>RXC</toolchain>
+    <board>ENVISIONRX72N</board>
+    <board>CloudKitRX65N</board>
+    <board>RSKRX65N-2MB</board>
     <family>RX</family>
     <series>RX600</series>
     <series>RX700</series>
-    <group>RX64M</group>
     <group>RX65N</group>
-    <group>RX71M</group>
-    <group>RX72M</group>
+    <group>RX72N</group>
   </target>
-  <additionaltarget>
-    <toolchain>GNUARM</toolchain>
-    <family>RZ</family>
-    <series>RZA</series>
-    <group>RZA2M</group>
-  </additionaltarget>
   <additionaltarget>
     <toolchain>GNURX</toolchain>
     <family>RX</family>
+    <board>CloudKitRX65N</board>
+    <board>RSKRX65N-2MB</board>
     <series>RX600</series>
     <series>RX700</series>
-    <group>RX64M</group>
     <group>RX65N</group>
-    <group>RX71M</group>
-    <group>RX72M</group>
   </additionaltarget>
   <!-- only one package entry allowed -->
   <!-- multiple dependencies, applications, functions, and incdirs permitted -->
   <package>
     <type>rtosmodule</type>
     <name>AmazonFreeRTOS_RX</name>
-    <version>v202002.00-rx-1.0.0</version>
+    <version>v202002.00-rx-1.0.1</version>
     <dependency>
       <module>r_bsp</module>
       <version>5.50</version>
@@ -85,14 +77,54 @@
       <libname>wchar.h</libname>
       <libname>wctype.h</libname>
     </standardlibrary>
+    <boardsupport>
+    <sections>
+        <toolchain>RXC</toolchain>
+        <board>CloudKitRX65N</board>
+        <section>
+            <name>SU</name>
+            <name>SI</name>
+            <address>0x00000004</address>
+        </section>
+        <section>
+            <name>C_PKCS11_STORAGE*</name>
+            <address>0x00100000</address>
+        </section>
+        <section>
+            <name>B_1</name>
+            <name>R_1</name>
+            <name>B_2</name>
+            <name>R_2</name>
+            <name>B</name>
+            <name>R</name>
+            <name>RPFRAM2</name>
+            <address>0x00800000</address>
+        </section>
+        <section>
+            <name>C_1</name>
+            <name>C_2</name>
+            <name>C</name>
+            <name>C$*</name>
+            <name>D*</name>
+            <name>W*</name>
+            <name>L</name>
+            <name>P*</name>
+            <address>0xFFF00300</address>
+        </section>
+        <section>
+            <name>EXCEPTVECT</name>
+            <address>0xFFFBFF80</address>
+        </section>
+        <section>
+            <name>RESETVECT</name>
+            <address>0xFFFBFFFC</address>
+        </section>
+    </sections>
+    </boardsupport>
     <sections>
       <toolchain>RXC</toolchain>
       <series>RX600</series>
-      <series>RX700</series>
-      <group>RX64M</group>
       <group>RX65N</group>
-      <group>RX71M</group>
-      <group>RX72M</group>
       <section>
         <name>SU</name>
         <name>SI</name>
@@ -123,6 +155,123 @@
         <address>0x00800000</address>
       </section>
     </sections>
+    <sections>
+      <toolchain>RXC</toolchain>
+      <series>RX700</series>
+      <group>RX71M</group>
+      <section>
+        <name>SU</name>
+        <name>SI</name>
+        <name>B_1</name>
+        <name>R_1</name>
+        <name>B_2</name>
+        <name>R_2</name>
+        <name>B</name>
+        <name>R</name>
+        <name>RPFRAM2</name>
+        <address>0x00000004</address>
+      </section>
+      <section>
+        <name>B_ETHERNET_BUFFERS_1</name>
+        <name>B_RX_DESC_1</name>
+        <name>B_TX_DESC_1</name>
+        <address>0x00065000</address>
+      </section>
+      <section>
+        <name>C_PKCS11_STORAGE*</name>
+        <address>0x00100000</address>
+      </section>
+    </sections>
+    <sections>
+      <toolchain>RXC</toolchain>
+      <series>RX700</series>
+      <group>RX72M</group>
+      <section>
+        <name>SU</name>
+        <name>SI</name>
+        <name>B_1</name>
+        <name>R_1</name>
+        <name>B_2</name>
+        <name>R_2</name>
+        <name>B</name>
+        <name>R</name>
+        <name>B_8</name>
+        <name>R_8</name>
+        <name>RPFRAM2</name>
+        <address>0x00000004</address>
+      </section>
+      <section>
+        <name>C_PKCS11_STORAGE*</name>
+        <address>0x00102000</address>
+      </section>
+      <section>
+        <name>B_ETHERNET_BUFFERS_1</name>
+        <name>B_RX_DESC_1</name>
+        <name>B_TX_DESC_1</name>
+        <address>0x00840000</address>
+      </section>
+    </sections>
+    <sections>
+      <toolchain>RXC</toolchain>
+      <series>RX600</series>
+      <group>RX64M</group>
+      <section>
+        <name>SU</name>
+        <name>SI</name>
+        <name>B_1</name>
+        <name>R_1</name>
+        <name>B_2</name>
+        <name>R_2</name>
+        <name>B</name>
+        <name>R</name>
+        <name>RPFRAM2</name>
+        <address>0x00000004</address>
+      </section>
+      <section>
+        <name>B_ETHERNET_BUFFERS_1</name>
+        <name>B_RX_DESC_1</name>
+        <name>B_TX_DESC_1</name>
+        <address>0x00050000</address>
+      </section>
+      <section>
+        <name>C_PKCS11_STORAGE*</name>
+        <address>0x00100000</address>
+      </section>
+    </sections>
+    <sections>
+      <toolchain>RXC</toolchain>
+      <series>RX700</series>
+      <group>RX72N</group>
+      <section>
+        <name>B_ETHERNET_BUFFERS_1</name>
+        <name>B_RX_DESC_1</name>
+        <name>B_TX_DESC_1</name>
+        <name>SU</name>
+        <name>SI</name>
+        <name>B_1</name>
+        <name>R_1</name>
+        <name>B_2</name>
+        <name>R_2</name>
+        <name>B</name>
+        <name>R</name>
+        <name>B_8</name>
+        <name>R_8</name>
+        <name>RPFRAM2*</name>
+        <address>0x00000000</address>
+      </section>
+      <section>
+        <name>C_BOOTLOADER_KEY_STORAGE*</name>
+        <address>0x00100000</address>
+      </section>
+      <section>
+        <name>C_PKCS11_STORAGE*</name>
+        <address>0x00100800</address>
+      </section>
+      <section>
+        <name>C_SYSTEM_CONFIG*</name>
+        <address>0x00104800</address>
+      </section>
+    </sections>
     <preinc>
       <toolchain>RXC</toolchain>
       <file>${AFR_HOME}/vendors/renesas/rx_mcu_boards/amazon_freertos_common/compiler_support/ccrx/implicitlyinclude.h</file>
@@ -135,6 +284,7 @@
         <group>RX65N</group>
         <group>RX71M</group>
         <group>RX72M</group>
+        <group>RX72N</group>
       <path>${AFR_HOME}/vendors/renesas/rx_mcu_boards/amazon_freertos_common/compiler_support/gnuc</path>
     </additionalincdir>
     <incdir>
@@ -145,17 +295,38 @@
       <group>RX65N</group>
       <group>RX71M</group>
       <group>RX72M</group>
+      <group>RX72N</group>
       <path>${AFR_HOME}/vendors/renesas/rx_mcu_boards/amazon_freertos_common/compiler_support/ccrx</path>
     </incdir>
     <incdir>
+      <board>Default</board>
       <series>RX600</series>
       <series>RX700</series>
       <group>RX64M</group>
       <group>RX65N</group>
       <group>RX71M</group>
       <group>RX72M</group>
+      <group>RX72N</group>
       <path>${AFR_HOME}/vendors/renesas/rx_mcu_boards/amazon_freertos_common/network_support/onchip_rx_ether</path>
     </incdir>
+    <boardsupport>
+      <incdir>
+          <board>RSKRX64M</board>
+          <board>RSKRX65N</board>
+          <board>RSKRX65N-2MB</board>
+          <board>RSKRX71M</board>
+          <board>RSKRX72M</board>
+          <board>ENVISIONRX72N</board>
+          <series>RX600</series>
+          <series>RX700</series>
+          <group>RX64M</group>
+          <group>RX65N</group>
+          <group>RX71M</group>
+          <group>RX72M</group>
+          <group>RX72N</group>
+          <path>${AFR_HOME}/vendors/renesas/rx_mcu_boards/amazon_freertos_common/network_support/onchip_rx_ether</path>
+      </incdir>
+    </boardsupport>
     <incdir>
       <series>RX600</series>
       <group>RX65N</group>
@@ -175,6 +346,11 @@
       <series>RX700</series>
       <group>RX72M</group>
       <path>${ProjDirPath}/application_code/renesas_code/smc_gen/r_bsp/board/generic_rx72m</path>
+    </incdir>
+    <incdir>
+      <series>RX700</series>
+      <group>RX72N</group>
+      <path>${ProjDirPath}/application_code/renesas_code/smc_gen/r_bsp/board/generic_rx72n</path>
     </incdir>
     <!--RZA2M -->
     <incdir>
@@ -218,7 +394,6 @@
       <path>${ProjDirPath}/application_code/renesas_code/smc_gen/general</path>
       <path>${ProjDirPath}/application_code/renesas_code/smc_gen/r_config</path>
       <path>${ProjDirPath}/application_code/renesas_code/smc_gen/r_pincfg</path>
-      <path>${ProjDirPath}/application_code/renesas_code/smc_gen/r_ether_rx</path>
       <path>${ProjDirPath}/application_code/renesas_code/smc_gen/r_flash_rx</path>
       <path>${ProjDirPath}/application_code/renesas_code/smc_gen/r_flash_rx/src</path>
       <path>${ProjDirPath}/application_code/renesas_code/smc_gen/r_flash_rx/src/flash_type_1</path>
@@ -240,7 +415,6 @@
       <path>${ProjDirPath}/application_code/renesas_code/smc_gen/general</path>
       <path>${ProjDirPath}/application_code/renesas_code/smc_gen/r_config</path>
       <path>${ProjDirPath}/application_code/renesas_code/smc_gen/r_pincfg</path>
-      <path>${ProjDirPath}/application_code/renesas_code/smc_gen/r_ether_rx</path>
       <path>${ProjDirPath}/application_code/renesas_code/smc_gen/r_flash_rx</path>
       <path>${ProjDirPath}/application_code/renesas_code/smc_gen/r_flash_rx/src</path>
       <path>${ProjDirPath}/application_code/renesas_code/smc_gen/r_flash_rx/src/flash_type_1</path>
@@ -255,6 +429,43 @@
       <path>${ProjDirPath}/application_code/renesas_code/smc_gen/r_s12ad_rx</path>
       <path>${ProjDirPath}/application_code/renesas_code/smc_gen/r_s12ad_rx/src</path>
     </incdir>
+    <incdir>
+      <board>Default</board>
+      <series>RX600</series>
+      <series>RX700</series>
+      <group>RX64M</group>
+      <group>RX65N</group>
+      <group>RX71M</group>
+      <group>RX72M</group>
+      <group>RX72N</group>
+      <path>${ProjDirPath}/application_code/renesas_code/smc_gen/r_ether_rx</path>
+    </incdir>
+    <boardsupport>
+      <incdir>
+          <board>RSKRX64M</board>
+          <board>RSKRX65N</board>
+          <board>RSKRX65N-2MB</board>
+          <board>RSKRX71M</board>
+          <board>RSKRX72M</board>
+          <board>ENVISIONRX72N</board>
+          <series>RX600</series>
+          <series>RX700</series>
+          <group>RX64M</group>
+          <group>RX65N</group>
+          <group>RX71M</group>
+          <group>RX72M</group>
+          <group>RX72N</group>
+      <path>${ProjDirPath}/application_code/renesas_code/smc_gen/r_ether_rx</path>
+      </incdir>
+    </boardsupport>
+    <boardsupport>
+    <incdir>
+        <board>CloudKitRX65N</board>
+        <path>${AFR_HOME}/libraries/abstractions/wifi/include</path>
+        <path>${ProjDirPath}/application_code/renesas_code/smc_gen/r_wifi_sx_ulpgn/src</path>
+        <path>${ProjDirPath}/application_code/renesas_code/smc_gen/r_wifi_sx_ulpgn</path>
+    </incdir>
+    </boardsupport>
     <incdir>
       <series>RX600</series>
       <group>RX64M</group>
@@ -276,6 +487,11 @@
       <path>${ProjDirPath}/application_code/renesas_code/smc_gen/r_sci_rx/src/targets/rx72m</path>
     </incdir>
     <incdir>
+      <series>RX700</series>
+      <group>RX72N</group>
+      <path>${ProjDirPath}/application_code/renesas_code/smc_gen/r_sci_rx/src/targets/rx72n</path>
+    </incdir>
+    <incdir>
       <series>RX600</series>
       <group>RX64M</group>
       <path>${ProjDirPath}/application_code/renesas_code/smc_gen/r_s12ad_rx/src/targets/rx64m</path>
@@ -295,15 +511,22 @@
       <group>RX72M</group>
       <path>${ProjDirPath}/application_code/renesas_code/smc_gen/r_s12ad_rx/src/targets/rx72m</path>
     </incdir>
-    <additionalincdir>
+    <incdir>
+      <series>RX700</series>
+      <group>RX72N</group>
+      <path>${ProjDirPath}/application_code/renesas_code/smc_gen/r_s12ad_rx/src/targets/rx72n</path>
+    </incdir>
+    <incdir>
         <toolchain>GNURX</toolchain>
         <series>RX600</series>
+        <series>RX700</series>
         <group>RX64M</group>
         <group>RX65N</group>
         <group>RX71M</group>
         <group>RX72M</group>
+        <group>RX72N</group>
         <path>${AFR_HOME}/freertos_kernel/portable/GCC/RX600v2</path>
-    </additionalincdir>
+    </incdir>
     <incdir>
       <toolchain>RXC</toolchain>
       <series>RX600</series>
@@ -312,6 +535,7 @@
       <group>RX65N</group>
       <group>RX71M</group>
       <group>RX72M</group>
+      <group>RX72N</group>
       <path>${AFR_HOME}/freertos_kernel/portable/Renesas/RX600v2</path>
     </incdir>
     <incdir>
@@ -325,58 +549,150 @@
       <path>${AFR_HOME}/libraries/abstractions/platform/include</path>
       <path>${AFR_HOME}/libraries/abstractions/platform/freertos/include</path>
       <path>${AFR_HOME}/libraries/abstractions/secure_sockets/include</path>
+    </incdir>
+    <incdir>
+      <board>Default</board>
+      <series>RX600</series>
+      <series>RX700</series>
+      <group>RX64M</group>
+      <group>RX65N</group>
+      <group>RX71M</group>
+      <group>RX72M</group>
+      <group>RX72N</group>
       <path>${AFR_HOME}/libraries/freertos_plus/standard/freertos_plus_tcp/test</path>
       <path>${AFR_HOME}/libraries/freertos_plus/standard/freertos_plus_tcp/include</path>
     </incdir>
+    <boardsupport>
+        <incdir>
+          <board>RSKRX64M</board>
+          <board>RSKRX65N</board>
+          <board>RSKRX65N-2MB</board>
+          <board>RSKRX71M</board>
+          <board>RSKRX72M</board>
+          <board>ENVISIONRX72N</board>
+          <series>RX600</series>
+          <series>RX700</series>
+          <group>RX64M</group>
+          <group>RX65N</group>
+          <group>RX71M</group>
+          <group>RX72M</group>
+          <group>RX72N</group>
+          <path>${AFR_HOME}/libraries/freertos_plus/standard/freertos_plus_tcp/test</path>
+          <path>${AFR_HOME}/libraries/freertos_plus/standard/freertos_plus_tcp/include</path>
+        </incdir>
+    </boardsupport>
     <incdir>
       <toolchain>GNURX</toolchain>
       <group>RX65N</group>
       <path>${AFR_HOME}/vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_bsp/mcu/rx65n/register_access/gnuc</path>
     </incdir>
-	<incdir>
+    <incdir>
       <toolchain>GNURX</toolchain>
-      <group>RX64N</group>
-      <path>${AFR_HOME}/vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_bsp/mcu/rx64n/register_access/gnuc</path>
+      <group>RX64M</group>
+      <path>${AFR_HOME}/vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_bsp/mcu/rx64m/register_access/gnuc</path>
     </incdir>
     <incdir>
       <toolchain>GNURX</toolchain>
       <group>RX71M</group>
       <path>${AFR_HOME}/vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_bsp/mcu/rx71m/register_access/gnuc</path>
     </incdir>
-	<incdir>
+    <incdir>
       <toolchain>GNURX</toolchain>
       <group>RX72M</group>
       <path>${AFR_HOME}/vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_bsp/mcu/rx72m/register_access/gnuc</path>
     </incdir>
-	<incdir>
+    <incdir>
+      <toolchain>GNURX</toolchain>
+      <group>RX72N</group>
+      <path>${AFR_HOME}/vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_bsp/mcu/rx72n/register_access/gnuc</path>
+    </incdir>
+    <incdir>
       <toolchain>RXC</toolchain>
       <group>RX65N</group>
       <path>${AFR_HOME}/vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_bsp/mcu/rx65n/register_access/ccrx</path>
     </incdir>
-	<incdir>
+    <incdir>
       <toolchain>RXC</toolchain>
-      <group>RX64N</group>
-      <path>${AFR_HOME}/vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_bsp/mcu/rx64n/register_access/ccrx</path>
+      <group>RX64M</group>
+      <path>${AFR_HOME}/vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_bsp/mcu/rx64m/register_access/ccrx</path>
     </incdir>
-	<incdir>
+    <incdir>
       <toolchain>RXC</toolchain>
       <group>RX71M</group>
       <path>${AFR_HOME}/vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_bsp/mcu/rx71m/register_access/ccrx</path>
     </incdir>
-	<incdir>
+    <incdir>
       <toolchain>RXC</toolchain>
       <group>RX72M</group>
       <path>${AFR_HOME}/vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_bsp/mcu/rx72m/register_access/ccrx</path>
     </incdir>
-	
     <incdir>
+      <toolchain>RXC</toolchain>
+      <group>RX72N</group>
+      <path>${AFR_HOME}/vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_bsp/mcu/rx72n/register_access/ccrx</path>
+    </incdir>
+    <incdir>
+      <board>Default</board>
+      <series>RX600</series>
+      <series>RX700</series>
+      <group>RX64M</group>
+      <group>RX65N</group>
+      <group>RX71M</group>
+      <group>RX72M</group>
+      <group>RX72N</group>
       <toolchain>GNURX</toolchain>
       <path>${AFR_HOME}/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/Compiler/GCC</path>
     </incdir>
+    <boardsupport>
+        <incdir>
+          <board>RSKRX64M</board>
+          <board>RSKRX65N</board>
+          <board>RSKRX65N-2MB</board>
+          <board>RSKRX71M</board>
+          <board>RSKRX72M</board>
+          <board>ENVISIONRX72N</board>
+          <series>RX600</series>
+          <series>RX700</series>
+          <group>RX64M</group>
+          <group>RX65N</group>
+          <group>RX71M</group>
+          <group>RX72M</group>
+          <group>RX72N</group>
+          <toolchain>GNURX</toolchain>
+          <path>${AFR_HOME}/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/Compiler/GCC</path>
+        </incdir>
+    </boardsupport>
     <incdir>
+      <board>Default</board>
+      <series>RX600</series>
+      <series>RX700</series>
+      <group>RX64M</group>
+      <group>RX65N</group>
+      <group>RX71M</group>
+      <group>RX72M</group>
+      <group>RX72N</group>
       <toolchain>RXC</toolchain>
       <path>${AFR_HOME}/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/Compiler/Renesas</path>
     </incdir>
+    <boardsupport>
+        <incdir>
+          <board>RSKRX64M</board>
+          <board>RSKRX65N</board>
+          <board>RSKRX65N-2MB</board>
+          <board>RSKRX71M</board>
+          <board>RSKRX72M</board>
+          <board>ENVISIONRX72N</board>
+          <series>RX600</series>
+          <series>RX700</series>
+          <group>RX64M</group>
+          <group>RX65N</group>
+          <group>RX71M</group>
+          <group>RX72M</group>
+          <group>RX72N</group>
+      <toolchain>RXC</toolchain>
+      <path>${AFR_HOME}/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/Compiler/Renesas</path>
+        </incdir>
+    </boardsupport>
     <!--RZA2M -->
     <incdir>
       <toolchain>GNUARM</toolchain>
@@ -421,6 +737,23 @@
       <file>vendors/renesas/rx_mcu_boards/boards/rx65n-rsk/aws_demos/application_code/main.c</file>
       <path>application_code</path>
     </impdir>
+    <boardsupport>
+    <impdir>
+      <board>CloudKitRX65N</board>
+        <toolchain>RXC</toolchain>
+        <file>vendors/renesas/rx_mcu_boards/boards/rx65n-cloud-kit-uart-sx-ulpgn/aws_demos/application_code/main.c</file>
+        <path>application_code</path>
+    </impdir>
+    </boardsupport>
+    <boardsupport>
+    <impdir>
+      <board>CloudKitRX65N</board>
+        <toolchain>GNURX</toolchain>
+        <!-- use main.c in rxc project, because in gcc project, main.c is not correct -->
+        <file>vendors/renesas/rx_mcu_boards/boards/rx65n-cloud-kit-uart-sx-ulpgn/aws_demos/application_code/main.c</file>
+        <path>application_code</path>
+    </impdir>
+    </boardsupport>
     <impdir>
       <series>RX700</series>
       <group>RX71M</group>
@@ -433,6 +766,12 @@
       <file>vendors/renesas/rx_mcu_boards/boards/rx72m-rsk/aws_demos/application_code/main.c</file>
       <path>application_code</path>
     </impdir>
+    <impdir>
+      <series>RX700</series>
+      <group>RX72N</group>
+      <file>vendors/renesas/rx_mcu_boards/boards/rx72n-envision-kit/aws_demos/application_code/main.c</file>
+      <path>application_code</path>
+    </impdir>
     <!--RZA2M -->
     <impdir>
       <series>RZA</series>
@@ -441,9 +780,74 @@
       <path>application_code</path>
     </impdir>
     <impdir>
+      <board>Default</board>
+      <series>RX600</series>
+      <series>RX700</series>
+      <group>RX64M</group>
+      <group>RX65N</group>
+      <group>RX71M</group>
+      <group>RX72M</group>
+      <group>RX72N</group>
       <folder>demos/demo_runner</folder>
       <path>application_code/demos/demo_runner</path>
     </impdir>
+    <boardsupport>
+      <impdir>
+          <board>RSKRX64M</board>
+          <board>RSKRX65N</board>
+          <board>RSKRX65N-2MB</board>
+          <board>RSKRX71M</board>
+          <board>RSKRX72M</board>
+          <board>ENVISIONRX72N</board>
+          <series>RX600</series>
+          <series>RX700</series>
+          <group>RX64M</group>
+          <group>RX65N</group>
+          <group>RX71M</group>
+          <group>RX72M</group>
+          <group>RX72N</group>
+          <folder>demos/demo_runner</folder>
+          <path>application_code/demos/demo_runner</path>
+      </impdir>
+    </boardsupport>
+    <boardsupport>
+      <impdir>
+        <board>CloudKitRX65N</board>
+        <folder>demos/defender</folder>
+        <path>application_code/demos/defender</path>
+      </impdir>
+    </boardsupport>
+    <boardsupport>
+      <impdir>
+        <board>CloudKitRX65N</board>
+        <file>demos/demo_runner/aws_demo_version.c</file>
+        <file>demos/demo_runner/aws_demo.c</file>
+        <file>demos/demo_runner/iot_demo_freertos.c</file>
+        <file>demos/demo_runner/iot_demo_runner.c</file>
+        <path>application_code/demos/demo_runner</path>
+      </impdir>
+    </boardsupport>
+    <boardsupport>
+      <impdir>
+        <board>CloudKitRX65N</board>
+        <folder>demos/greengrass_connectivity</folder>
+        <path>application_code/demos/greengrass_connectivity</path>
+      </impdir>
+    </boardsupport>
+    <boardsupport>
+      <impdir>
+                <board>CloudKitRX65N</board>
+                <folder>demos/shadow</folder>
+                <path>application_code/demos/shadow</path>
+            </impdir>
+    </boardsupport>
+    <boardsupport>
+            <impdir>
+                <board>CloudKitRX65N</board>
+                <folder>demos/tcp</folder>
+                <path>application_code/demos/tcp</path>
+            </impdir>
+    </boardsupport>
     <impdir>
       <file>demos/dev_mode_key_provisioning/include/aws_dev_mode_key_provisioning.h</file>
       <path>application_code/demos/dev_mode_key_provisioning/include</path>
@@ -482,29 +886,94 @@
       <path>application_code/demos/network_manager</path>
     </impdir>
     <impdir>
+      <board>Default</board>
       <series>RX600</series>
       <group>RX64M</group>
       <folder>vendors/renesas/rx_mcu_boards/boards/rx64m-rsk/aws_demos/config_files/</folder>
       <path>config_files</path>
     </impdir>
+    <boardsupport>
+      <impdir>
+          <board>RSKRX64M</board>
+          <series>RX600</series>
+          <group>RX64M</group>
+          <folder>vendors/renesas/rx_mcu_boards/boards/rx64m-rsk/aws_demos/config_files/</folder>
+          <path>config_files</path>
+      </impdir>
+    </boardsupport>
     <impdir>
+      <board>Default</board>
       <series>RX600</series>
       <group>RX65N</group>
       <folder>vendors/renesas/rx_mcu_boards/boards/rx65n-rsk/aws_demos/config_files/</folder>
       <path>config_files</path>
     </impdir>
+    <boardsupport>
     <impdir>
+      <board>RSKRX65N</board>
+      <board>RSKRX65N-2MB</board>
+      <series>RX600</series>
+      <group>RX65N</group>
+      <folder>vendors/renesas/rx_mcu_boards/boards/rx65n-rsk/aws_demos/config_files/</folder>
+      <path>config_files</path>
+    </impdir>
+    </boardsupport>
+    <boardsupport>
+      <impdir>
+        <board>CloudKitRX65N</board>
+        <toolchain>RXC</toolchain>
+        <folder>vendors/renesas/rx_mcu_boards/boards/rx65n-cloud-kit-uart-sx-ulpgn/aws_demos/config_files/</folder>
+        <path>config_files</path>
+      </impdir>
+    </boardsupport>
+    <impdir>
+      <board>Default</board>
       <series>RX700</series>
       <group>RX71M</group>
       <folder>vendors/renesas/rx_mcu_boards/boards/rx71m-rsk/aws_demos/config_files/</folder>
       <path>config_files</path>
     </impdir>
+    <boardsupport>
     <impdir>
+      <board>RSKRX71M</board>
+      <series>RX700</series>
+      <group>RX71M</group>
+      <folder>vendors/renesas/rx_mcu_boards/boards/rx71m-rsk/aws_demos/config_files/</folder>
+      <path>config_files</path>
+    </impdir>
+    </boardsupport>
+    <impdir>
+      <board>Default</board>
       <series>RX700</series>
       <group>RX72M</group>
       <folder>vendors/renesas/rx_mcu_boards/boards/rx72m-rsk/aws_demos/config_files/</folder>
       <path>config_files</path>
     </impdir>
+    <boardsupport>
+    <impdir>
+      <board>RSKRX72M</board>
+      <series>RX700</series>
+      <group>RX72M</group>
+      <folder>vendors/renesas/rx_mcu_boards/boards/rx72m-rsk/aws_demos/config_files/</folder>
+      <path>config_files</path>
+    </impdir>
+    </boardsupport>
+    <impdir>
+      <board>Default</board>
+      <series>RX700</series>
+      <group>RX72N</group>
+      <folder>vendors/renesas/rx_mcu_boards/boards/rx72n-envision-kit/aws_demos/config_files/</folder>
+      <path>config_files</path>
+    </impdir>
+    <boardsupport>
+    <impdir>
+      <board>ENVISIONRX72N</board>
+      <series>RX700</series>
+      <group>RX72N</group>
+      <folder>vendors/renesas/rx_mcu_boards/boards/rx72n-envision-kit/aws_demos/config_files/</folder>
+      <path>config_files</path>
+    </impdir>
+    </boardsupport>
     <!--RZA2M -->
     <impdir>
       <series>RZA</series>
@@ -519,61 +988,203 @@
       <path>.settings/smartconfigurator</path>
     </impdir>
     <impdir>
+      <board>Default</board>
       <toolchain>RXC</toolchain>
       <series>RX600</series>
       <group>RX64M</group>
       <file>projects/renesas/rx64m-rsk/e2studio/aws_demos/application_code/renesas_code/frtos_skeleton/task_function.h</file>
       <path>application_code/renesas_code/frtos_skeleton</path>
     </impdir>
+    <boardsupport>
     <impdir>
+      <board>RSKRX64M</board>
+      <toolchain>RXC</toolchain>
+      <series>RX600</series>
+      <group>RX64M</group>
+      <file>projects/renesas/rx64m-rsk/e2studio/aws_demos/application_code/renesas_code/frtos_skeleton/task_function.h</file>
+      <path>application_code/renesas_code/frtos_skeleton</path>
+    </impdir>
+    </boardsupport>
+    <impdir>
+      <board>Default</board>
       <toolchain>RXC</toolchain>
       <series>RX600</series>
       <group>RX65N</group>
       <file>projects/renesas/rx65n-rsk/e2studio/aws_demos/application_code/renesas_code/frtos_skeleton/task_function.h</file>
       <path>application_code/renesas_code/frtos_skeleton</path>
     </impdir>
+    <boardsupport>
     <impdir>
+      <board>RSKRX65N</board>
+      <board>RSKRX65N-2MB</board>
+      <toolchain>RXC</toolchain>
+      <series>RX600</series>
+      <group>RX65N</group>
+      <file>projects/renesas/rx65n-rsk/e2studio/aws_demos/application_code/renesas_code/frtos_skeleton/task_function.h</file>
+      <path>application_code/renesas_code/frtos_skeleton</path>
+    </impdir>
+    </boardsupport>
+    <boardsupport>
+      <impdir>
+        <board>CloudKitRX65N</board>
+        <toolchain>RXC</toolchain>
+        <file>projects/renesas/rx65n-cloud-kit-uart-sx-ulpgn/e2studio/aws_demos/application_code/renesas_code/frtos_skeleton/task_function.h</file>
+        <path>application_code/renesas_code/frtos_skeleton</path>
+      </impdir>
+    </boardsupport>
+    <impdir>
+      <board>Default</board>
       <toolchain>RXC</toolchain>
       <series>RX700</series>
       <group>RX71M</group>
       <file>projects/renesas/rx71m-rsk/e2studio/aws_demos/application_code/renesas_code/frtos_skeleton/task_function.h</file>
       <path>application_code/renesas_code/frtos_skeleton</path>
     </impdir>
+    <boardsupport>
     <impdir>
+      <board>RSKRX71M</board>
+      <toolchain>RXC</toolchain>
+      <series>RX700</series>
+      <group>RX71M</group>
+      <file>projects/renesas/rx71m-rsk/e2studio/aws_demos/application_code/renesas_code/frtos_skeleton/task_function.h</file>
+      <path>application_code/renesas_code/frtos_skeleton</path>
+    </impdir>
+    </boardsupport>
+    <impdir>
+      <board>Default</board>
       <toolchain>RXC</toolchain>
       <series>RX700</series>
       <group>RX72M</group>
       <file>projects/renesas/rx72m-rsk/e2studio/aws_demos/application_code/renesas_code/frtos_skeleton/task_function.h</file>
       <path>application_code/renesas_code/frtos_skeleton</path>
     </impdir>
+    <boardsupport>
     <impdir>
+      <board>RSKRX72M</board>
+      <toolchain>RXC</toolchain>
+      <series>RX700</series>
+      <group>RX72M</group>
+      <file>projects/renesas/rx72m-rsk/e2studio/aws_demos/application_code/renesas_code/frtos_skeleton/task_function.h</file>
+      <path>application_code/renesas_code/frtos_skeleton</path>
+    </impdir>
+    </boardsupport>
+    <impdir>
+      <board>Default</board>
+      <toolchain>RXC</toolchain>
+      <series>RX700</series>
+      <group>RX72N</group>
+      <file>projects/renesas/rx72n_envision_kit/e2studio/aws_demos/application_code/renesas_code/frtos_skeleton/task_function.h</file>
+      <path>application_code/renesas_code/frtos_skeleton</path>
+    </impdir>
+    <boardsupport>
+    <impdir>
+      <board>ENVISIONRX72N</board>
+      <toolchain>RXC</toolchain>
+      <series>RX700</series>
+      <group>RX72N</group>
+      <file>projects/renesas/rx72n_envision_kit/e2studio/aws_demos/application_code/renesas_code/frtos_skeleton/task_function.h</file>
+      <path>application_code/renesas_code/frtos_skeleton</path>
+    </impdir>
+    </boardsupport>
+    <impdir>
+      <board>Default</board>
       <toolchain>RXC</toolchain>
       <series>RX600</series>
       <group>RX64M</group>
       <file>projects/renesas/rx64m-rsk/e2studio/aws_demos/application_code/renesas_code/frtos_startup/freertos_object_init.c</file>
       <path>application_code/renesas_code/frtos_startup</path>
     </impdir>
+    <boardsupport>
     <impdir>
+      <board>RSKRX64M</board>
+      <toolchain>RXC</toolchain>
+      <series>RX600</series>
+      <group>RX64M</group>
+      <file>projects/renesas/rx64m-rsk/e2studio/aws_demos/application_code/renesas_code/frtos_startup/freertos_object_init.c</file>
+      <path>application_code/renesas_code/frtos_startup</path>
+    </impdir>
+    </boardsupport>
+    <impdir>
+      <board>Default</board>
       <toolchain>RXC</toolchain>
       <series>RX600</series>
       <group>RX65N</group>
       <file>projects/renesas/rx65n-rsk/e2studio/aws_demos/application_code/renesas_code/frtos_startup/freertos_object_init.c</file>
       <path>application_code/renesas_code/frtos_startup</path>
     </impdir>
+    <boardsupport>
     <impdir>
+      <board>RSKRX65N</board>
+      <board>RSKRX65N-2MB</board>
+      <toolchain>RXC</toolchain>
+      <series>RX600</series>
+      <group>RX65N</group>
+      <file>projects/renesas/rx65n-rsk/e2studio/aws_demos/application_code/renesas_code/frtos_startup/freertos_object_init.c</file>
+      <path>application_code/renesas_code/frtos_startup</path>
+    </impdir>
+    </boardsupport>
+    <boardsupport>
+      <impdir>
+        <board>CloudKitRX65N</board>
+        <toolchain>RXC</toolchain>
+        <file>projects/renesas/rx65n-cloud-kit-uart-sx-ulpgn/e2studio/aws_demos/application_code/renesas_code/frtos_startup/freertos_object_init.c</file>
+        <path>application_code/renesas_code/frtos_startup</path>
+      </impdir>
+    </boardsupport>
+    <impdir>
+      <board>Default</board>
       <toolchain>RXC</toolchain>
       <series>RX700</series>
       <group>RX71M</group>
       <file>projects/renesas/rx71m-rsk/e2studio/aws_demos/application_code/renesas_code/frtos_startup/freertos_object_init.c</file>
       <path>application_code/renesas_code/frtos_startup</path>
     </impdir>
+    <boardsupport>
     <impdir>
+      <board>RSKRX71M</board>
+      <toolchain>RXC</toolchain>
+      <series>RX700</series>
+      <group>RX71M</group>
+      <file>projects/renesas/rx71m-rsk/e2studio/aws_demos/application_code/renesas_code/frtos_startup/freertos_object_init.c</file>
+      <path>application_code/renesas_code/frtos_startup</path>
+    </impdir>
+    </boardsupport>
+    <impdir>
+      <board>Default</board>
       <toolchain>RXC</toolchain>
       <series>RX700</series>
       <group>RX72M</group>
       <file>projects/renesas/rx72m-rsk/e2studio/aws_demos/application_code/renesas_code/frtos_startup/freertos_object_init.c</file>
       <path>application_code/renesas_code/frtos_startup</path>
     </impdir>
+    <boardsupport>
+    <impdir>
+      <board>RSKRX72M</board>
+      <toolchain>RXC</toolchain>
+      <series>RX700</series>
+      <group>RX72M</group>
+      <file>projects/renesas/rx72m-rsk/e2studio/aws_demos/application_code/renesas_code/frtos_startup/freertos_object_init.c</file>
+      <path>application_code/renesas_code/frtos_startup</path>
+    </impdir>
+    </boardsupport>
+    <impdir>
+      <board>Default</board>
+      <toolchain>RXC</toolchain>
+      <series>RX700</series>
+      <group>RX72N</group>
+      <file>projects/renesas/rx72n_envision_kit/e2studio/aws_demos/application_code/renesas_code/frtos_startup/freertos_object_init.c</file>
+      <path>application_code/renesas_code/frtos_startup</path>
+    </impdir>
+    <boardsupport>
+    <impdir>
+      <board>ENVISIONRX72N</board>
+      <toolchain>RXC</toolchain>
+      <series>RX700</series>
+      <group>RX72N</group>
+      <file>projects/renesas/rx65n-rsk/e2studio/aws_demos/application_code/renesas_code/frtos_startup/freertos_object_init.c</file>
+      <path>application_code/renesas_code/frtos_startup</path>
+    </impdir>
+    </boardsupport>
     <impdir>
       <series>RX600</series>
       <series>RX700</series>
@@ -581,38 +1192,110 @@
       <group>RX64M</group>
       <group>RX71M</group>
       <group>RX72M</group>
+      <group>RX72N</group>
       <file>vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_bsp/platform.h</file>
       <file>vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_bsp/readme.txt</file>
       <path>application_code/renesas_code/smc_gen/r_bsp</path>
     </impdir>
     <impdir>
+      <board>Default</board>
+      <toolchain>GNURX</toolchain>
+      <series>RX600</series>
+      <group>RX64M</group>
+      <file>projects/renesas/rx64m-rsk/e2studio-gcc/aws_demos/linker_script.ld</file>
+      <path></path>
+    </impdir>
+    <boardsupport>
+    <impdir>
+      <board>RSKRX64M</board>
+      <toolchain>GNURX</toolchain>
+      <series>RX600</series>
+      <group>RX64M</group>
+      <file>projects/renesas/rx64m-rsk/e2studio-gcc/aws_demos/linker_script.ld</file>
+      <path></path>
+    </impdir>
+    </boardsupport>
+    <impdir>
+      <board>Default</board>
       <toolchain>GNURX</toolchain>
       <series>RX600</series>
       <group>RX65N</group>
       <file>projects/renesas/rx65n-rsk/e2studio-gcc/aws_demos/linker_script.ld</file>
       <path></path>
     </impdir>
+    <boardsupport>
     <impdir>
+      <board>RSKRX65N</board>
+      <board>RSKRX65N-2MB</board>
       <toolchain>GNURX</toolchain>
       <series>RX600</series>
-      <group>RX64M</group>
-      <file>projects/renesas/rx64n-rsk/e2studio-gcc/aws_demos/linker_script.ld</file>
+      <group>RX65N</group>
+      <file>projects/renesas/rx65n-rsk/e2studio-gcc/aws_demos/linker_script.ld</file>
       <path></path>
     </impdir>
+    </boardsupport>
+    <boardsupport>
+      <impdir>
+        <board>CloudKitRX65N</board>
+        <toolchain>RXC</toolchain>
+        <file>projects/renesas/rx65n-cloud-kit-uart-sx-ulpgn/e2studio/aws_demos/linker_script.ld</file>
+        <path/>
+      </impdir>
+    </boardsupport>
     <impdir>
+      <board>Default</board>
       <toolchain>GNURX</toolchain>
       <series>RX700</series>
       <group>RX71M</group>
       <file>projects/renesas/rx71m-rsk/e2studio-gcc/aws_demos/linker_script.ld</file>
       <path></path>
     </impdir>
+    <boardsupport>
     <impdir>
+      <board>RSKRX71M</board>
+      <toolchain>GNURX</toolchain>
+      <series>RX700</series>
+      <group>RX71M</group>
+      <file>projects/renesas/rx71m-rsk/e2studio-gcc/aws_demos/linker_script.ld</file>
+      <path></path>
+    </impdir>
+    </boardsupport>
+    <impdir>
+      <board>Default</board>
       <toolchain>GNURX</toolchain>
       <series>RX700</series>
       <group>RX72M</group>
       <file>projects/renesas/rx72m-rsk/e2studio-gcc/aws_demos/linker_script.ld</file>
       <path></path>
     </impdir>
+    <boardsupport>
+    <impdir>
+      <board>RSKRX72M</board>
+      <toolchain>GNURX</toolchain>
+      <series>RX700</series>
+      <group>RX72M</group>
+      <file>projects/renesas/rx72m-rsk/e2studio-gcc/aws_demos/linker_script.ld</file>
+      <path></path>
+    </impdir>
+    </boardsupport>
+    <impdir>
+      <board>Default</board>
+      <toolchain>GNURX</toolchain>
+      <series>RX700</series>
+      <group>RX72N</group>
+      <file>projects/renesas/rx72n_envision_kit/e2studio-gcc/aws_demos/linker_script.ld</file>
+      <path></path>
+    </impdir>
+    <boardsupport>
+    <impdir>
+      <board>ENVISIONRX72N</board>
+      <toolchain>GNURX</toolchain>
+      <series>RX700</series>
+      <group>RX72N</group>
+      <file>projects/renesas/rx72n_envision_kit/e2studio-gcc/aws_demos/linker_script.ld</file>
+      <path></path>
+    </impdir>
+    </boardsupport>
     <impdir>
       <series>RX600</series>
       <group>RX64M</group>
@@ -638,12 +1321,19 @@
       <path>application_code/renesas_code/smc_gen/r_bsp/board/generic_rx72m</path>
     </impdir>
     <impdir>
+      <series>RX700</series>
+      <group>RX72N</group>
+      <folder>vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_bsp/board/generic_rx72n</folder>
+      <path>application_code/renesas_code/smc_gen/r_bsp/board/generic_rx72n</path>
+    </impdir>
+    <impdir>
       <series>RX600</series>
       <series>RX700</series>
       <group>RX65N</group>
       <group>RX64M</group>
       <group>RX71M</group>
       <group>RX72M</group>
+      <group>RX72N</group>
       <folder>vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_bsp/mcu/all</folder>
       <path>application_code/renesas_code/smc_gen/r_bsp/mcu/all</path>
     </impdir>
@@ -654,7 +1344,6 @@
       <path>application_code/renesas_code/smc_gen/r_bsp/mcu/rx64m</path>
     </impdir>
     <impdir>
-      <toolchain>GNURX</toolchain>
       <series>RX600</series>
       <group>RX65N</group>
       <folder>vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_bsp/mcu/rx65n</folder>
@@ -673,61 +1362,228 @@
       <path>application_code/renesas_code/smc_gen/r_bsp/mcu/rx72m</path>
     </impdir>
     <impdir>
+      <series>RX700</series>
+      <group>RX72N</group>
+      <folder>vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_bsp/mcu/rx72n</folder>
+      <path>application_code/renesas_code/smc_gen/r_bsp/mcu/rx72n</path>
+    </impdir>
+    <impdir>
       <series>RX600</series>
       <series>RX700</series>
       <folder>vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_byteq</folder>
       <path>application_code/renesas_code/smc_gen/r_byteq</path>
     </impdir>
     <impdir>
+      <board>Default</board>
       <series>RX600</series>
       <series>RX700</series>
       <folder>vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_ether_rx/src/phy</folder>
       <path>application_code/renesas_code/smc_gen/r_ether_rx/src/phy</path>
     </impdir>
+    <boardsupport>
     <impdir>
+      <board>RSKRX64M</board>
+      <board>RSKRX65N</board>
+      <board>RSKRX65N-2MB</board>
+      <board>RSKRX71M</board>
+      <board>RSKRX72M</board>
+      <board>ENVISIONRX72N</board>
+      <series>RX600</series>
+      <series>RX700</series>
+      <folder>vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_ether_rx/src/phy</folder>
+      <path>application_code/renesas_code/smc_gen/r_ether_rx/src/phy</path>
+    </impdir>
+    </boardsupport>
+    <impdir>
+      <board>Default</board>
       <series>RX600</series>
       <group>RX64M</group>
       <file>vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_ether_rx/src/targets/rx64m/r_ether_setting_rx64m.c</file>
       <path>application_code/renesas_code/smc_gen/r_ether_rx/src/targets/rx64m</path>
     </impdir>
+    <boardsupport>
     <impdir>
+      <board>RSKRX64M</board>
+      <series>RX600</series>
+      <group>RX64M</group>
+      <file>vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_ether_rx/src/targets/rx64m/r_ether_setting_rx64m.c</file>
+      <path>application_code/renesas_code/smc_gen/r_ether_rx/src/targets/rx64m</path>
+    </impdir>
+    </boardsupport>
+    <impdir>
+      <board>Default</board>
       <series>RX600</series>
       <group>RX65N</group>
       <file>vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_ether_rx/src/targets/rx65n/r_ether_setting_rx65n.c</file>
       <path>application_code/renesas_code/smc_gen/r_ether_rx/src/targets/rx65n</path>
     </impdir>
+    <boardsupport>
     <impdir>
+      <board>RSKRX65N</board>
+      <board>RSKRX65N-2MB</board>
+      <series>RX600</series>
+      <group>RX65N</group>
+      <file>vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_ether_rx/src/targets/rx65n/r_ether_setting_rx65n.c</file>
+      <path>application_code/renesas_code/smc_gen/r_ether_rx/src/targets/rx65n</path>
+    </impdir>
+    </boardsupport>
+    <impdir>
+      <board>Default</board>
       <series>RX700</series>
       <group>RX71M</group>
       <file>vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_ether_rx/src/targets/rx71m/r_ether_setting_rx71m.c</file>
       <path>application_code/renesas_code/smc_gen/r_ether_rx/src/targets/rx71m</path>
     </impdir>
+    <boardsupport>
     <impdir>
+      <board>RSKRX71M</board>
+      <series>RX700</series>
+      <group>RX71M</group>
+      <file>vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_ether_rx/src/targets/rx71m/r_ether_setting_rx71m.c</file>
+      <path>application_code/renesas_code/smc_gen/r_ether_rx/src/targets/rx71m</path>
+    </impdir>
+    </boardsupport>
+    <impdir>
+      <board>Default</board>
       <series>RX700</series>
       <group>RX72M</group>
       <file>vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_ether_rx/src/targets/rx72m/r_ether_setting_rx72m.c</file>
       <path>application_code/renesas_code/smc_gen/r_ether_rx/src/targets/rx72m</path>
     </impdir>
+    <boardsupport>
     <impdir>
+      <board>RSKRX72M</board>
+      <series>RX700</series>
+      <group>RX72M</group>
+      <file>vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_ether_rx/src/targets/rx72m/r_ether_setting_rx72m.c</file>
+      <path>application_code/renesas_code/smc_gen/r_ether_rx/src/targets/rx72m</path>
+    </impdir>
+    </boardsupport>
+    <impdir>
+      <board>Default</board>
+      <series>RX700</series>
+      <group>RX72N</group>
+      <file>vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_ether_rx/src/targets/rx72n/r_ether_setting_rx72n.c</file>
+      <path>application_code/renesas_code/smc_gen/r_ether_rx/src/targets/rx72n</path>
+    </impdir>
+    <boardsupport>
+    <impdir>
+      <board>ENVISIONRX72N</board>
+      <series>RX700</series>
+      <group>RX72N</group>
+      <file>vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_ether_rx/src/targets/rx72n/r_ether_setting_rx72n.c</file>
+      <path>application_code/renesas_code/smc_gen/r_ether_rx/src/targets/rx72n</path>
+    </impdir>
+    </boardsupport>
+    <impdir>
+      <board>Default</board>
+      <toolchain>RXC</toolchain>
       <series>RX600</series>
       <series>RX700</series>
       <file>vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_ether_rx/src/r_ether_rx_private.h</file>
       <file>vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_ether_rx/src/r_ether_rx.c</file>
       <path>application_code/renesas_code/smc_gen/r_ether_rx/src</path>
     </impdir>
+    <boardsupport>
     <impdir>
+      <board>RSKRX64M</board>
+      <board>RSKRX65N</board>
+      <board>RSKRX65N-2MB</board>
+      <board>RSKRX71M</board>
+      <board>RSKRX72M</board>
+      <board>ENVISIONRX72N</board>
+      <toolchain>RXC</toolchain>
       <series>RX600</series>
       <series>RX700</series>
-	  <folder>vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_ether_rx/ref</folder>
+      <file>vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_ether_rx/src/r_ether_rx_private.h</file>
+      <file>vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_ether_rx/src/r_ether_rx.c</file>
+      <path>application_code/renesas_code/smc_gen/r_ether_rx/src</path>
+    </impdir>
+    </boardsupport>
+    <impdir>
+      <board>Default</board>
+      <toolchain>RXC</toolchain>
+      <series>RX600</series>
+      <series>RX700</series>
+      <folder>vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_ether_rx/ref</folder>
       <file>vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_ether_rx/r_ether_rx_if.h</file>
       <file>vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_ether_rx/readme.txt</file>
       <path>application_code/renesas_code/smc_gen/r_ether_rx</path>
     </impdir>
+    <boardsupport>
+   <impdir>
+      <board>RSKRX64M</board>
+      <board>RSKRX65N</board>
+      <board>RSKRX65N-2MB</board>
+      <board>RSKRX71M</board>
+      <board>RSKRX72M</board>
+      <board>ENVISIONRX72N</board>
+      <toolchain>RXC</toolchain>
+      <series>RX600</series>
+      <series>RX700</series>
+      <folder>vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_ether_rx/ref</folder>
+      <file>vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_ether_rx/r_ether_rx_if.h</file>
+      <file>vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_ether_rx/readme.txt</file>
+      <path>application_code/renesas_code/smc_gen/r_ether_rx</path>
+    </impdir>
+    </boardsupport>
+    <impdir>
+      <board>Default</board>
+      <toolchain>GNURX</toolchain>
+      <series>RX600</series>
+      <series>RX700</series>
+      <file>vendors/renesas/rx_mcu_boards/rx_driver_package/v123/r_ether_rx/src/r_ether_rx_private.h</file>
+      <file>vendors/renesas/rx_mcu_boards/rx_driver_package/v123/r_ether_rx/src/r_ether_rx.c</file>
+      <path>application_code/renesas_code/smc_gen/r_ether_rx/src</path>
+    </impdir>
+    <boardsupport>
+    <impdir>
+      <board>RSKRX64M</board>
+      <board>RSKRX65N</board>
+      <board>RSKRX65N-2MB</board>
+      <board>RSKRX71M</board>
+      <board>RSKRX72M</board>
+      <board>ENVISIONRX72N</board>
+      <toolchain>GNURX</toolchain>
+      <series>RX600</series>
+      <series>RX700</series>
+      <file>vendors/renesas/rx_mcu_boards/rx_driver_package/v123/r_ether_rx/src/r_ether_rx_private.h</file>
+      <file>vendors/renesas/rx_mcu_boards/rx_driver_package/v123/r_ether_rx/src/r_ether_rx.c</file>
+      <path>application_code/renesas_code/smc_gen/r_ether_rx/src</path>
+    </impdir>
+    </boardsupport>
+    <impdir>
+      <board>Default</board>
+      <toolchain>GNURX</toolchain>
+      <series>RX600</series>
+      <series>RX700</series>
+      <folder>vendors/renesas/rx_mcu_boards/rx_driver_package/v123/r_ether_rx/ref</folder>
+      <file>vendors/renesas/rx_mcu_boards/rx_driver_package/v123/r_ether_rx/r_ether_rx_if.h</file>
+      <file>vendors/renesas/rx_mcu_boards/rx_driver_package/v123/r_ether_rx/readme.txt</file>
+      <path>application_code/renesas_code/smc_gen/r_ether_rx</path>
+    </impdir>
+    <boardsupport>
+    <impdir>
+      <board>RSKRX64M</board>
+      <board>RSKRX65N</board>
+      <board>RSKRX65N-2MB</board>
+      <board>RSKRX71M</board>
+      <board>RSKRX72M</board>
+      <board>ENVISIONRX72N</board>
+      <toolchain>GNURX</toolchain>
+      <series>RX600</series>
+      <series>RX700</series>
+      <folder>vendors/renesas/rx_mcu_boards/rx_driver_package/v123/r_ether_rx/ref</folder>
+      <file>vendors/renesas/rx_mcu_boards/rx_driver_package/v123/r_ether_rx/r_ether_rx_if.h</file>
+      <file>vendors/renesas/rx_mcu_boards/rx_driver_package/v123/r_ether_rx/readme.txt</file>
+      <path>application_code/renesas_code/smc_gen/r_ether_rx</path>
+    </impdir>
+    </boardsupport>
     <impdir>
       <series>RX600</series>
       <series>RX700</series>
       <folder>vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_flash_rx/ref</folder>
-	  <file>vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_flash_rx/r_flash_rx_if.h</file>
+      <file>vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_flash_rx/r_flash_rx_if.h</file>
       <file>vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_flash_rx/readme.txt</file>
       <path>application_code/renesas_code/smc_gen/r_flash_rx</path>
     </impdir>
@@ -735,10 +1591,25 @@
       <series>RX600</series>
       <series>RX700</series>
       <folder>vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_flash_rx/src/flash_type_1</folder>
+      <path>application_code/renesas_code/smc_gen/r_flash_rx/src/flash_type_1</path>
+    </impdir>
+    <impdir>
+      <series>RX600</series>
+      <series>RX700</series>
       <folder>vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_flash_rx/src/flash_type_2</folder>
+      <path>application_code/renesas_code/smc_gen/r_flash_rx/src/flash_type_2</path>
+    </impdir>
+    <impdir>
+      <series>RX600</series>
+      <series>RX700</series>
       <folder>vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_flash_rx/src/flash_type_3</folder>
+      <path>application_code/renesas_code/smc_gen/r_flash_rx/src/flash_type_3</path>
+    </impdir>
+    <impdir>
+      <series>RX600</series>
+      <series>RX700</series>
       <folder>vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_flash_rx/src/flash_type_4</folder>
-      <path>application_code/renesas_code/smc_gen/r_flash_rx/src</path>
+      <path>application_code/renesas_code/smc_gen/r_flash_rx/src/flash_type_4</path>
     </impdir>
     <impdir>
       <series>RX600</series>
@@ -763,6 +1634,12 @@
       <group>RX72M</group>
       <file>vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_flash_rx/src/targets/rx72m/r_flash_rx72m.h</file>
       <path>application_code/renesas_code/smc_gen/r_flash_rx/src/targets/rx72m</path>
+    </impdir>
+    <impdir>
+      <series>RX700</series>
+      <group>RX72N</group>
+      <file>vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_flash_rx/src/targets/rx72n/r_flash_rx72n.h</file>
+      <path>application_code/renesas_code/smc_gen/r_flash_rx/src/targets/rx72n</path>
     </impdir>
     <impdir>
       <series>RX600</series>
@@ -812,13 +1689,19 @@
       <path>application_code/renesas_code/smc_gen/r_s12ad_rx/src/targets/rx72m</path>
     </impdir>
     <impdir>
+      <series>RX700</series>
+      <group>RX72N</group>
+      <file>vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_s12ad_rx/src/targets/rx72n/r_s12ad_rx72n.c</file>
+      <file>vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_s12ad_rx/src/targets/rx72n/r_s12ad_rx72n_if.h</file>
+      <path>application_code/renesas_code/smc_gen/r_s12ad_rx/src/targets/rx72n</path>
+    </impdir>
+    <impdir>
       <series>RX600</series>
       <series>RX700</series>
       <file>vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_s12ad_rx/src/r_s12ad_rx.c</file>
       <file>vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_s12ad_rx/src/r_s12ad_rx_private.h</file>
       <path>application_code/renesas_code/smc_gen/r_s12ad_rx/src</path>
     </impdir>
-
     <impdir>
       <series>RX600</series>
       <group>RX64M</group>
@@ -852,10 +1735,19 @@
       <path>application_code/renesas_code/smc_gen/r_sci_rx/src/targets/rx72m</path>
     </impdir>
     <impdir>
+      <series>RX700</series>
+      <group>RX72N</group>
+      <file>vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_sci_rx/src/targets/rx72n/r_sci_rx72n.c</file>
+      <file>vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_sci_rx/src/targets/rx72n/r_sci_rx72n_data.c</file>
+      <file>vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_sci_rx/src/targets/rx72n/r_sci_rx72n_private.h</file>
+      <path>application_code/renesas_code/smc_gen/r_sci_rx/src/targets/rx72n</path>
+    </impdir>
+    <impdir>
       <group>RX64M</group>
       <group>RX65N</group>
       <group>RX71M</group>
       <group>RX72M</group>
+      <group>RX72N</group>
       <file>vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_sci_rx/src/r_sci_rx.c</file>
       <file>vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_sci_rx/src/r_sci_rx_platform.h</file>
       <file>vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_sci_rx/src/r_sci_rx_private.h</file>
@@ -866,66 +1758,315 @@
       <group>RX65N</group>
       <group>RX71M</group>
       <group>RX72M</group>
-	  <folder>vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_sci_rx/ref</folder>
+      <group>RX72N</group>
+      <folder>vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_sci_rx/ref</folder>
       <file>vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_sci_rx/r_sci_rx_if.h</file>
       <file>vendors/renesas/rx_mcu_boards/rx_driver_package/v125/r_sci_rx/readme.txt</file>
       <path>application_code/renesas_code/smc_gen/r_sci_rx</path>
     </impdir>
-    <impdir>
+    <boardsupport>
+      <impdir>
       <toolchain>GNURX</toolchain>
+      <board>RSKRX64M</board>
       <series>RX600</series>
       <group>RX64M</group>
-      <folder>vendors/renesas/rx_mcu_boards/boards/rx64m-rsk-gcc/aws_demos/gcc/src/smc_gen/general</folder>
+      <folder>vendors/renesas/rx_mcu_boards/boards/rx64m-rsk-gcc/aws_demos/src/smc_gen/</folder>
       <path>application_code/renesas_code/smc_gen</path>
-    </impdir>
-    <impdir>
+      </impdir>
+    </boardsupport>
+    <boardsupport>
+      <impdir>
       <toolchain>RXC</toolchain>
+      <board>RSKRX64M</board>
       <series>RX600</series>
       <group>RX64M</group>
       <folder>vendors/renesas/rx_mcu_boards/boards/rx64m-rsk/aws_demos/src/smc_gen/</folder>
       <path>application_code/renesas_code/smc_gen</path>
-    </impdir>
-    <impdir>
+      </impdir>
+    </boardsupport>
+    <boardsupport>
+      <impdir>
       <toolchain>GNURX</toolchain>
+      <board>RSKRX65N</board>
+      <board>RSKRX65N-2MB</board>
       <series>RX600</series>
       <group>RX65N</group>
-      <folder>vendors/renesas/rx_mcu_boards/boards/rx65n-rsk-gcc/aws_demos/gcc/src/smc_gen</folder>
+      <folder>vendors/renesas/rx_mcu_boards/boards/rx65n-rsk-gcc/aws_demos/src/smc_gen/</folder>
       <path>application_code/renesas_code/smc_gen</path>
-    </impdir>
-    <impdir>
+      </impdir>
+    </boardsupport>
+    <boardsupport>
+      <impdir>
       <toolchain>RXC</toolchain>
+      <board>RSKRX65N</board>
+      <board>RSKRX65N-2MB</board>
       <series>RX600</series>
       <group>RX65N</group>
-      <folder>vendors/renesas/rx_mcu_boards/boards/rx65n-rsk/aws_demos/src/smc_gen</folder>
+      <folder>vendors/renesas/rx_mcu_boards/boards/rx65n-rsk/aws_demos/src/smc_gen/</folder>
       <path>application_code/renesas_code/smc_gen</path>
+      </impdir>
+    </boardsupport>
+    <boardsupport>
+      <impdir>
+        <board>CloudKitRX65N</board>
+        <toolchain>RXC</toolchain>
+        <folder>vendors/renesas/rx_mcu_boards/boards/rx65n-cloud-kit-uart-sx-ulpgn/aws_demos/src/smc_gen</folder>
+        <path>application_code/renesas_code/smc_gen</path>
+      </impdir>
+    </boardsupport>
+    <boardsupport>
+      <impdir>
+        <board>CloudKitRX65N</board>
+        <toolchain>GNURX</toolchain>
+        <folder>vendors/renesas/rx_mcu_boards/boards/rx65n-cloud-kit-uart-sx-ulpgn-gcc/aws_demos/src/smc_gen</folder>
+        <path>application_code/renesas_code/smc_gen</path>
+      </impdir>
+    </boardsupport>
+    <boardsupport>
+      <impdir>
+      <toolchain>GNURX</toolchain>
+      <board>RSKRX71M</board>
+      <series>RX700</series>
+      <group>RX71M</group>
+      <folder>vendors/renesas/rx_mcu_boards/boards/rx71m-rsk-gcc/aws_demos/src/smc_gen/</folder>
+      <path>application_code/renesas_code/smc_gen</path>
+      </impdir>
+    </boardsupport>
+    <boardsupport>
+      <impdir>
+      <toolchain>RXC</toolchain>
+      <board>RSKRX71M</board>
+      <series>RX700</series>
+      <group>RX71M</group>
+      <folder>vendors/renesas/rx_mcu_boards/boards/rx71m-rsk/aws_demos/src/smc_gen/</folder>
+      <path>application_code/renesas_code/smc_gen</path>
+      </impdir>
+    </boardsupport>
+    <boardsupport>
+      <impdir>
+      <toolchain>GNURX</toolchain>
+      <board>RSKRX72M</board>
+      <series>RX700</series>
+      <group>RX72M</group>
+      <folder>vendors/renesas/rx_mcu_boards/boards/rx72m-rsk-gcc/aws_demos/src/smc_gen/</folder>
+      <path>application_code/renesas_code/smc_gen</path>
+      </impdir>
+    </boardsupport>
+    <boardsupport>
+      <impdir>
+      <toolchain>RXC</toolchain>
+      <board>RSKRX72M</board>
+      <series>RX700</series>
+      <group>RX72M</group>
+      <folder>vendors/renesas/rx_mcu_boards/boards/rx72m-rsk/aws_demos/src/smc_gen/</folder>
+      <path>application_code/renesas_code/smc_gen</path>
+      </impdir>
+    </boardsupport>
+    <boardsupport>
+      <impdir>
+      <toolchain>GNURX</toolchain>
+      <board>ENVISIONRX72N</board>
+      <series>RX700</series>
+      <group>RX72N</group>
+      <folder>vendors/renesas/rx_mcu_boards/boards/rx72n-envision-kit-gcc/aws_demos/src/smc_gen/</folder>
+      <path>application_code/renesas_code/smc_gen</path>
+      </impdir>
+    </boardsupport>
+    <boardsupport>
+      <impdir>
+      <toolchain>RXC</toolchain>
+      <board>ENVISIONRX72N</board>
+      <series>RX700</series>
+      <group>RX72N</group>
+      <folder>vendors/renesas/rx_mcu_boards/boards/rx72n-envision-kit/aws_demos/src/smc_gen/</folder>
+      <path>application_code/renesas_code/smc_gen</path>
+      </impdir>
+    </boardsupport>
+    <impdir>
+      <toolchain>GNURX</toolchain>
+        <board>Default</board>
+        <series>RX600</series>
+        <group>RX64M</group>
+        <folder>vendors/renesas/rx_mcu_boards/boards/rx64m-rsk-gcc/aws_demos/src/smc_gen/general</folder>
+        <path>application_code/renesas_code/smc_gen/general</path>
     </impdir>
     <impdir>
       <toolchain>GNURX</toolchain>
-      <series>RX700</series>
-      <group>RX71M</group>
-      <folder>vendors/renesas/rx_mcu_boards/boards/rx71m-rsk-gcc/aws_demos/gcc/src/smc_gen</folder>
-      <path>application_code/renesas_code/smc_gen</path>
+        <board>Default</board>
+        <series>RX600</series>
+        <group>RX64M</group>
+        <folder>vendors/renesas/rx_mcu_boards/boards/rx64m-rsk-gcc/aws_demos/src/smc_gen/r_config</folder>
+        <path>application_code/renesas_code/smc_gen/r_config</path>
     </impdir>
     <impdir>
       <toolchain>RXC</toolchain>
-      <series>RX700</series>
-      <group>RX71M</group>
-      <folder>vendors/renesas/rx_mcu_boards/boards/rx71m-rsk/aws_demos/src/smc_gen</folder>
-      <path>application_code/renesas_code/smc_gen</path>
+        <board>Default</board>
+        <series>RX600</series>
+        <group>RX64M</group>
+        <folder>vendors/renesas/rx_mcu_boards/boards/rx64m-rsk/aws_demos/src/smc_gen/general</folder>
+        <path>application_code/renesas_code/smc_gen/general</path>
     </impdir>
     <impdir>
       <toolchain>RXC</toolchain>
-      <series>RX700</series>
-      <group>RX72M</group>
-      <folder>vendors/renesas/rx_mcu_boards/boards/rx72m-rsk/aws_demos/src/smc_gen</folder>
-      <path>application_code/renesas_code/smc_gen</path>
+        <board>Default</board>
+        <series>RX600</series>
+        <group>RX64M</group>
+        <folder>vendors/renesas/rx_mcu_boards/boards/rx64m-rsk/aws_demos/src/smc_gen/r_config</folder>
+        <path>application_code/renesas_code/smc_gen/r_config</path>
     </impdir>
     <impdir>
       <toolchain>GNURX</toolchain>
+        <board>Default</board>
+        <series>RX600</series>
+        <group>RX65N</group>
+        <folder>vendors/renesas/rx_mcu_boards/boards/rx65n-rsk-gcc/aws_demos/src/smc_gen/general</folder>
+        <path>application_code/renesas_code/smc_gen/general</path>
+    </impdir>
+    <impdir>
+      <toolchain>GNURX</toolchain>
+        <board>Default</board>
+        <series>RX600</series>
+        <group>RX65N</group>
+        <folder>vendors/renesas/rx_mcu_boards/boards/rx65n-rsk-gcc/aws_demos/src/smc_gen/r_config</folder>
+        <path>application_code/renesas_code/smc_gen/r_config</path>
+    </impdir>
+    <impdir>
+      <toolchain>RXC</toolchain>
+        <board>Default</board>
+        <series>RX600</series>
+        <group>RX65N</group>
+        <folder>vendors/renesas/rx_mcu_boards/boards/rx65n-rsk/aws_demos/src/smc_gen/general</folder>
+        <path>application_code/renesas_code/smc_gen/general</path>
+    </impdir>
+    <impdir>
+      <toolchain>RXC</toolchain>
+        <board>Default</board>
+        <series>RX600</series>
+        <group>RX65N</group>
+        <folder>vendors/renesas/rx_mcu_boards/boards/rx65n-rsk/aws_demos/src/smc_gen/r_config</folder>
+        <path>application_code/renesas_code/smc_gen/r_config</path>
+    </impdir>
+    <impdir>
+      <toolchain>GNURX</toolchain>
+        <board>Default</board>
+        <series>RX700</series>
+        <group>RX71M</group>
+        <folder>vendors/renesas/rx_mcu_boards/boards/rx71m-rsk-gcc/aws_demos/src/smc_gen/general</folder>
+        <path>application_code/renesas_code/smc_gen/general</path>
+    </impdir>
+    <impdir>
+      <toolchain>GNURX</toolchain>
+        <board>Default</board>
+        <series>RX700</series>
+        <group>RX71M</group>
+        <folder>vendors/renesas/rx_mcu_boards/boards/rx71m-rsk-gcc/aws_demos/src/smc_gen/r_config</folder>
+        <path>application_code/renesas_code/smc_gen/r_config</path>
+    </impdir>
+    <impdir>
+      <toolchain>RXC</toolchain>
+        <board>Default</board>
+        <series>RX700</series>
+        <group>RX71M</group>
+        <folder>vendors/renesas/rx_mcu_boards/boards/rx71m-rsk/aws_demos/src/smc_gen/general</folder>
+        <path>application_code/renesas_code/smc_gen/general</path>
+    </impdir>
+    <impdir>
+      <toolchain>RXC</toolchain>
+        <board>Default</board>
+        <series>RX700</series>
+        <group>RX71M</group>
+        <folder>vendors/renesas/rx_mcu_boards/boards/rx71m-rsk/aws_demos/src/smc_gen/r_config</folder>
+        <path>application_code/renesas_code/smc_gen/r_config</path>
+    </impdir>
+    <impdir>
+      <toolchain>GNURX</toolchain>
+        <board>Default</board>
+        <series>RX700</series>
+        <group>RX72M</group>
+        <folder>vendors/renesas/rx_mcu_boards/boards/rx72m-rsk-gcc/aws_demos/src/smc_gen/general</folder>
+        <path>application_code/renesas_code/smc_gen/general</path>
+    </impdir>
+    <impdir>
+      <toolchain>GNURX</toolchain>
+        <board>Default</board>
+        <series>RX700</series>
+        <group>RX72M</group>
+        <folder>vendors/renesas/rx_mcu_boards/boards/rx72m-rsk-gcc/aws_demos/src/smc_gen/r_config</folder>
+        <path>application_code/renesas_code/smc_gen/r_config</path>
+    </impdir>
+    <impdir>
+      <toolchain>RXC</toolchain>
+        <board>Default</board>
+        <series>RX700</series>
+        <group>RX72M</group>
+        <folder>vendors/renesas/rx_mcu_boards/boards/rx72m-rsk/aws_demos/src/smc_gen/r_config</folder>
+        <path>application_code/renesas_code/smc_gen/r_config</path>
+    </impdir>
+    <impdir>
+      <toolchain>RXC</toolchain>
+        <board>Default</board>
+        <series>RX700</series>
+        <group>RX72M</group>
+        <folder>vendors/renesas/rx_mcu_boards/boards/rx72m-rsk/aws_demos/src/smc_gen/general</folder>
+        <path>application_code/renesas_code/smc_gen/general</path>
+    </impdir>
+    <impdir>
+      <toolchain>GNURX</toolchain>
+        <board>Default</board>
+        <series>RX700</series>
+        <group>RX72N</group>
+        <folder>vendors/renesas/rx_mcu_boards/boards/rx72n-envision-kit-gcc/aws_demos/src/smc_gen/general</folder>
+        <path>application_code/renesas_code/smc_gen/general</path>
+    </impdir>
+    <impdir>
+      <toolchain>GNURX</toolchain>
+        <board>Default</board>
+        <series>RX700</series>
+        <group>RX72N</group>
+        <folder>vendors/renesas/rx_mcu_boards/boards/rx72n-envision-kit-gcc/aws_demos/src/smc_gen/r_config</folder>
+        <path>application_code/renesas_code/smc_gen/r_config</path>
+    </impdir>
+    <impdir>
+      <toolchain>RXC</toolchain>
+        <board>Default</board>
+        <series>RX700</series>
+        <group>RX72N</group>
+        <folder>vendors/renesas/rx_mcu_boards/boards/rx72n-envision-kit/aws_demos/src/smc_gen/general</folder>
+        <path>application_code/renesas_code/smc_gen/general</path>
+    </impdir>
+    <impdir>
+      <toolchain>RXC</toolchain>
+        <board>Default</board>
+        <series>RX700</series>
+        <group>RX72N</group>
+        <folder>vendors/renesas/rx_mcu_boards/boards/rx72n-envision-kit/aws_demos/src/smc_gen/r_config</folder>
+        <path>application_code/renesas_code/smc_gen/r_config</path>
+    </impdir>
+    <impdir>
+      <toolchain>GNURX</toolchain>
+      <board>Default</board>
+      <series>RX600</series>
       <series>RX700</series>
+      <group>RX64M</group>
+      <group>RX65N</group>
+      <group>RX71M</group>
       <group>RX72M</group>
-      <folder>vendors/renesas/rx_mcu_boards/boards/rx72m-rsk-gcc/aws_demos/gcc/src/smc_gen</folder>
-      <path>application_code/renesas_code/smc_gen</path>
+      <group>RX72N</group>
+      <folder>vendors/renesas/rx_mcu_boards/boards/custom/aws_demos/src/smc_gen/r_pincfg</folder>
+      <path>application_code/renesas_code/smc_gen/r_pincfg</path>
+    </impdir>
+    <impdir>
+      <toolchain>RXC</toolchain>
+      <board>Default</board>
+      <series>RX600</series>
+      <series>RX700</series>
+      <group>RX64M</group>
+      <group>RX65N</group>
+      <group>RX71M</group>
+      <group>RX72M</group>
+      <group>RX72N</group>
+      <folder>vendors/renesas/rx_mcu_boards/boards/custom/aws_demos/src/smc_gen/r_pincfg</folder>
+      <path>application_code/renesas_code/smc_gen/r_pincfg</path>
     </impdir>
     <!--RZA2M -->
     <impdir>
@@ -950,6 +2091,7 @@
       <group>RX64M</group>
       <group>RX71M</group>
       <group>RX72M</group>
+      <group>RX72N</group>
       <file>${PROJECT_LOC}/linker_script.ld</file>
     </linkerscript>
     <linkerscript>
@@ -1012,6 +2154,7 @@
       <group>RX65N</group>
       <group>RX71M</group>
       <group>RX72M</group>
+      <group>RX72N</group>
       <file>freertos_kernel/portable/GCC/RX600v2/port.c</file>
       <file>freertos_kernel/portable/GCC/RX600v2/portmacro.h</file>
       <path>freertos_kernel/portable/GCC/RX600v2</path>
@@ -1024,6 +2167,7 @@
       <group>RX65N</group>
       <group>RX71M</group>
       <group>RX72M</group>
+      <group>RX72N</group>
       <file>freertos_kernel/portable/Renesas/RX600v2/port.c</file>
       <file>freertos_kernel/portable/Renesas/RX600v2/port_asm.src</file>
       <file>freertos_kernel/portable/Renesas/RX600v2/portmacro.h</file>
@@ -1251,9 +2395,22 @@
       <path>libraries/abstractions/platform/include/types</path>
     </linkdir>
     <linkdir>
+      <board>Default</board>
       <file>libraries/abstractions/secure_sockets/freertos_plus_tcp/iot_secure_sockets.c</file>
       <path>libraries/abstractions/secure_sockets/freertos_plus_tcp</path>
     </linkdir>
+    <boardsupport>
+    <linkdir>
+      <board>RSKRX64M</board>
+      <board>RSKRX65N</board>
+      <board>RSKRX65N-2MB</board>
+      <board>RSKRX71M</board>
+      <board>RSKRX72M</board>
+      <board>ENVISIONRX72N</board>
+      <file>libraries/abstractions/secure_sockets/freertos_plus_tcp/iot_secure_sockets.c</file>
+      <path>libraries/abstractions/secure_sockets/freertos_plus_tcp</path>
+    </linkdir>
+    </boardsupport>
     <linkdir>
       <file>libraries/abstractions/secure_sockets/include/iot_secure_sockets_config_defaults.h</file>
       <file>libraries/abstractions/secure_sockets/include/iot_secure_sockets_wrapper_metrics.h</file>
@@ -1301,7 +2458,7 @@
     </linkdir>
     <linkdir>
       <file>libraries/c_sdk/standard/common/include/iot_appversion32.h</file>
-	  <file>libraries/c_sdk/standard/common/include/iot_atomic.h</file>
+      <file>libraries/c_sdk/standard/common/include/iot_atomic.h</file>
       <file>libraries/c_sdk/standard/common/include/iot_init.h</file>
       <file>libraries/c_sdk/standard/common/include/iot_linear_containers.h</file>
       <file>libraries/c_sdk/standard/common/include/iot_logging_setup.h</file>
@@ -1407,6 +2564,7 @@
       <path>libraries/freertos_plus/standard/crypto/src</path>
     </linkdir>
     <linkdir>
+      <board>Default</board>
       <file>libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_ARP.h</file>
       <file>libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_DHCP.h</file>
       <file>libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_DNS.h</file>
@@ -1424,17 +2582,65 @@
       <file>libraries/freertos_plus/standard/freertos_plus_tcp/include/NetworkInterface.h</file>
       <path>libraries/freertos_plus/standard/freertos_plus_tcp/include</path>
     </linkdir>
+    <boardsupport>
     <linkdir>
+      <board>RSKRX64M</board>
+      <board>RSKRX65N</board>
+      <board>RSKRX65N-2MB</board>
+      <board>RSKRX71M</board>
+      <board>RSKRX72M</board>
+      <board>ENVISIONRX72N</board>
+      <file>libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_ARP.h</file>
+      <file>libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_DHCP.h</file>
+      <file>libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_DNS.h</file>
+      <file>libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_errno_TCP.h</file>
+      <file>libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_IP_Private.h</file>
+      <file>libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_IP.h</file>
+      <file>libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_Sockets.h</file>
+      <file>libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_Stream_Buffer.h</file>
+      <file>libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_TCP_IP.h</file>
+      <file>libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_TCP_WIN.h</file>
+      <file>libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_UDP_IP.h</file>
+      <file>libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOSIPConfigDefaults.h</file>
+      <file>libraries/freertos_plus/standard/freertos_plus_tcp/include/IPTraceMacroDefaults.h</file>
+      <file>libraries/freertos_plus/standard/freertos_plus_tcp/include/NetworkBufferManagement.h</file>
+      <file>libraries/freertos_plus/standard/freertos_plus_tcp/include/NetworkInterface.h</file>
+      <path>libraries/freertos_plus/standard/freertos_plus_tcp/include</path>
+    </linkdir>
+    </boardsupport>
+    <linkdir>
+      <board>Default</board>
       <series>RX600</series>
       <series>RX700</series>
       <group>RX64M</group>
       <group>RX65N</group>
       <group>RX71M</group>
       <group>RX72M</group>
+      <group>RX72N</group>
       <file>libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/BufferManagement/BufferAllocation_2.c</file>
       <path>libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/BufferManagement</path>
     </linkdir>
+    <boardsupport>
     <linkdir>
+      <board>RSKRX64M</board>
+      <board>RSKRX65N</board>
+      <board>RSKRX65N-2MB</board>
+      <board>RSKRX71M</board>
+      <board>RSKRX72M</board>
+      <board>ENVISIONRX72N</board>
+      <series>RX600</series>
+      <series>RX700</series>
+      <group>RX64M</group>
+      <group>RX65N</group>
+      <group>RX71M</group>
+      <group>RX72M</group>
+      <group>RX72N</group>
+      <file>libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/BufferManagement/BufferAllocation_2.c</file>
+      <path>libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/BufferManagement</path>
+    </linkdir>
+    </boardsupport>
+    <linkdir>
+      <board>Default</board>
       <toolchain>RXC</toolchain>
       <series>RX600</series>
       <series>RX700</series>
@@ -1442,10 +2648,32 @@
       <group>RX65N</group>
       <group>RX71M</group>
       <group>RX72M</group>
+      <group>RX72N</group>
       <folder>libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/Compiler/Renesas</folder>
       <path>libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/Compiler/RX</path>
     </linkdir>
+    <boardsupport>
     <linkdir>
+      <board>RSKRX64M</board>
+      <board>RSKRX65N</board>
+      <board>RSKRX65N-2MB</board>
+      <board>RSKRX71M</board>
+      <board>RSKRX72M</board>
+      <board>ENVISIONRX72N</board>
+      <toolchain>RXC</toolchain>
+      <series>RX600</series>
+      <series>RX700</series>
+      <group>RX64M</group>
+      <group>RX65N</group>
+      <group>RX71M</group>
+      <group>RX72M</group>
+      <group>RX72N</group>
+      <folder>libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/Compiler/Renesas</folder>
+      <path>libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/Compiler/RX</path>
+    </linkdir>
+    </boardsupport>
+    <linkdir>
+      <board>Default</board>
       <toolchain>GNURX</toolchain>
       <series>RX600</series>
       <series>RX700</series>
@@ -1453,20 +2681,63 @@
       <group>RX65N</group>
       <group>RX71M</group>
       <group>RX72M</group>
+      <group>RX72N</group>
       <folder>libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/Compiler/GCC</folder>
       <path>libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/GCC</path>
     </linkdir>
+    <boardsupport>
     <linkdir>
+      <board>RSKRX64M</board>
+      <board>RSKRX65N</board>
+      <board>RSKRX65N-2MB</board>
+      <board>RSKRX71M</board>
+      <board>RSKRX72M</board>
+      <board>ENVISIONRX72N</board>
+      <toolchain>GNURX</toolchain>
       <series>RX600</series>
       <series>RX700</series>
       <group>RX64M</group>
       <group>RX65N</group>
       <group>RX71M</group>
       <group>RX72M</group>
+      <group>RX72N</group>
+      <folder>libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/Compiler/GCC</folder>
+      <path>libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/GCC</path>
+    </linkdir>
+    </boardsupport>
+    <linkdir>
+      <board>Default</board>
+      <series>RX600</series>
+      <series>RX700</series>
+      <group>RX64M</group>
+      <group>RX65N</group>
+      <group>RX71M</group>
+      <group>RX72M</group>
+      <group>RX72N</group>
       <file>libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/RX/ether_callback.c</file>
       <file>libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/RX/NetworkInterface.c</file>
       <path>libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/RX</path>
     </linkdir>
+    <boardsupport>
+    <linkdir>
+      <board>RSKRX64M</board>
+      <board>RSKRX65N</board>
+      <board>RSKRX65N-2MB</board>
+      <board>RSKRX71M</board>
+      <board>RSKRX72M</board>
+      <board>ENVISIONRX72N</board>
+      <series>RX600</series>
+      <series>RX700</series>
+      <group>RX64M</group>
+      <group>RX65N</group>
+      <group>RX71M</group>
+      <group>RX72M</group>
+      <group>RX72N</group>
+      <file>libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/RX/ether_callback.c</file>
+      <file>libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/RX/NetworkInterface.c</file>
+      <path>libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/NetworkInterface/RX</path>
+    </linkdir>
+    </boardsupport>
     <!--RZA2M -->
     <linkdir>
       <series>RZA</series>
@@ -1482,6 +2753,7 @@
       <path>libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/BufferManagement</path>
     </linkdir>
     <linkdir>
+      <board>Default</board>
       <file>libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_ARP.c</file>
       <file>libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DHCP.c</file>
       <file>libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c</file>
@@ -1493,6 +2765,26 @@
       <file>libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_UDP_IP.c</file>
       <path>libraries/freertos_plus/standard/freertos_plus_tcp/source</path>
     </linkdir>
+    <boardsupport>
+    <linkdir>
+      <board>RSKRX64M</board>
+      <board>RSKRX65N</board>
+      <board>RSKRX65N-2MB</board>
+      <board>RSKRX71M</board>
+      <board>RSKRX72M</board>
+      <board>ENVISIONRX72N</board>
+      <file>libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_ARP.c</file>
+      <file>libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DHCP.c</file>
+      <file>libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c</file>
+      <file>libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_IP.c</file>
+      <file>libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_Sockets.c</file>
+      <file>libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_Stream_Buffer.c</file>
+      <file>libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_TCP_IP.c</file>
+      <file>libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_TCP_WIN.c</file>
+      <file>libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_UDP_IP.c</file>
+      <path>libraries/freertos_plus/standard/freertos_plus_tcp/source</path>
+    </linkdir>
+    </boardsupport>
     <linkdir>
       <file>libraries/freertos_plus/standard/pkcs11/include/iot_pkcs11.h</file>
       <path>libraries/freertos_plus/standard/pkcs11/include</path>
@@ -1534,22 +2826,45 @@
       <path>vendors/renesas/rx_mcu_boards/amazon_freertos_common/compiler_support/ccrx</path>
     </linkdir>
     <linkdir>
+      <board>Default</board>
       <series>RX600</series>
       <series>RX700</series>
       <group>RX64M</group>
       <group>RX65N</group>
       <group>RX71M</group>
       <group>RX72M</group>
+      <group>RX72N</group>
       <file>vendors/renesas/rx_mcu_boards/amazon_freertos_common/network_support/onchip_rx_ether/freertos_ip_hook.c</file>
       <path>vendors/renesas/rx_mcu_boards/amazon_freertos_common/network_support/onchip_rx_ether</path>
     </linkdir>
+    <boardsupport>
     <linkdir>
+      <board>RSKRX64M</board>
+      <board>RSKRX65N</board>
+      <board>RSKRX65N-2MB</board>
+      <board>RSKRX71M</board>
+      <board>RSKRX72M</board>
+      <board>ENVISIONRX72N</board>
       <series>RX600</series>
       <series>RX700</series>
       <group>RX64M</group>
       <group>RX65N</group>
       <group>RX71M</group>
       <group>RX72M</group>
+      <group>RX72N</group>
+      <file>vendors/renesas/rx_mcu_boards/amazon_freertos_common/network_support/onchip_rx_ether/freertos_ip_hook.c</file>
+      <path>vendors/renesas/rx_mcu_boards/amazon_freertos_common/network_support/onchip_rx_ether</path>
+    </linkdir>
+    </boardsupport>
+    <linkdir>
+      <board>Default</board>
+      <series>RX600</series>
+      <series>RX700</series>
+      <group>RX64M</group>
+      <group>RX65N</group>
+      <group>RX71M</group>
+      <group>RX72M</group>
+      <group>RX72N</group>
       <file>vendors/renesas/rx_mcu_boards/amazon_freertos_common/croutine.h</file>
       <file>vendors/renesas/rx_mcu_boards/amazon_freertos_common/entropy_hardware_poll.c</file>
       <file>vendors/renesas/rx_mcu_boards/amazon_freertos_common/freertos_start.c</file>
@@ -1558,118 +2873,474 @@
       <file>vendors/renesas/rx_mcu_boards/amazon_freertos_common/serial_term_uart.h</file>
       <path>vendors/renesas/rx_mcu_boards/amazon_freertos_common</path>
     </linkdir>
+    <boardsupport>
     <linkdir>
+      <board>RSKRX64M</board>
+      <board>RSKRX65N</board>
+      <board>RSKRX65N-2MB</board>
+      <board>CloudKitRX65N</board>
+      <board>RSKRX71M</board>
+      <board>RSKRX72M</board>
+      <board>ENVISIONRX72N</board>
+      <series>RX600</series>
+      <series>RX700</series>
+      <group>RX64M</group>
+      <group>RX65N</group>
+      <group>RX71M</group>
+      <group>RX72M</group>
+      <group>RX72N</group>
+      <file>vendors/renesas/rx_mcu_boards/amazon_freertos_common/croutine.h</file>
+      <file>vendors/renesas/rx_mcu_boards/amazon_freertos_common/entropy_hardware_poll.c</file>
+      <file>vendors/renesas/rx_mcu_boards/amazon_freertos_common/freertos_start.c</file>
+      <file>vendors/renesas/rx_mcu_boards/amazon_freertos_common/freertos_start.h</file>
+      <file>vendors/renesas/rx_mcu_boards/amazon_freertos_common/serial_term_uart.c</file>
+      <file>vendors/renesas/rx_mcu_boards/amazon_freertos_common/serial_term_uart.h</file>
+      <path>vendors/renesas/rx_mcu_boards/amazon_freertos_common</path>
+    </linkdir>
+    </boardsupport>
+      <linkdir>
+      <board>Default</board>
       <toolchain>GNURX</toolchain>
       <series>RX600</series>
       <group>RX64M</group>
       <file>vendors/renesas/rx_mcu_boards/boards/rx64m-rsk-gcc/ports/pkcs11/iot_pkcs11_pal.c</file>
       <path>vendors/renesas/rx_mcu_boards/boards/rx64m-rsk-gcc/ports/pkcs11</path>
-    </linkdir>
-    <linkdir>
+      </linkdir>
+    <boardsupport>
+      <linkdir>
+      <board>RSKRX64M</board>
+      <toolchain>GNURX</toolchain>
+      <series>RX600</series>
+      <group>RX64M</group>
+      <file>vendors/renesas/rx_mcu_boards/boards/rx64m-rsk-gcc/ports/pkcs11/iot_pkcs11_pal.c</file>
+      <path>vendors/renesas/rx_mcu_boards/boards/rx64m-rsk-gcc/ports/pkcs11</path>
+      </linkdir>
+    </boardsupport>
+      <linkdir>
+      <board>Default</board>
       <toolchain>RXC</toolchain>
       <series>RX600</series>
       <group>RX64M</group>
       <file>vendors/renesas/rx_mcu_boards/boards/rx64m-rsk/ports/pkcs11/iot_pkcs11_pal.c</file>
       <path>vendors/renesas/rx_mcu_boards/boards/rx64m-rsk/ports/pkcs11</path>
-    </linkdir>
-	<linkdir>
+      </linkdir>
+    <boardsupport>
+      <linkdir>
+      <board>RSKRX64M</board>
+      <toolchain>RXC</toolchain>
+      <series>RX600</series>
+      <group>RX64M</group>
+      <file>vendors/renesas/rx_mcu_boards/boards/rx64m-rsk/ports/pkcs11/iot_pkcs11_pal.c</file>
+      <path>vendors/renesas/rx_mcu_boards/boards/rx64m-rsk/ports/pkcs11</path>
+      </linkdir>
+    </boardsupport>
+      <linkdir>
+      <board>Default</board>
       <toolchain>GNURX</toolchain>
       <series>RX600</series>
       <group>RX64M</group>
       <file>vendors/renesas/rx_mcu_boards/boards/rx64m-rsk-gcc/ports/ota/aws_ota_pal.c</file>
       <path>vendors/renesas/rx_mcu_boards/boards/rx64m-rsk-gcc/ports/ota</path>
-    </linkdir>
-    <linkdir>
+      </linkdir>
+    <boardsupport>
+      <linkdir>
+      <board>RSKRX64M</board>
+      <toolchain>GNURX</toolchain>
+      <series>RX600</series>
+      <group>RX64M</group>
+      <file>vendors/renesas/rx_mcu_boards/boards/rx64m-rsk-gcc/ports/ota/aws_ota_pal.c</file>
+      <path>vendors/renesas/rx_mcu_boards/boards/rx64m-rsk-gcc/ports/ota</path>
+      </linkdir>
+    </boardsupport>
+      <linkdir>
+      <board>Default</board>
       <toolchain>RXC</toolchain>
       <series>RX600</series>
       <group>RX64M</group>
       <file>vendors/renesas/rx_mcu_boards/boards/rx64m-rsk/ports/ota/aws_ota_pal.c</file>
       <path>vendors/renesas/rx_mcu_boards/boards/rx64m-rsk/ports/ota</path>
-    </linkdir>
-    <linkdir>
+      </linkdir>
+    <boardsupport>
+      <linkdir>
+      <board>RSKRX64M</board>
+      <toolchain>RXC</toolchain>
+      <series>RX600</series>
+      <group>RX64M</group>
+      <file>vendors/renesas/rx_mcu_boards/boards/rx64m-rsk/ports/ota/aws_ota_pal.c</file>
+      <path>vendors/renesas/rx_mcu_boards/boards/rx64m-rsk/ports/ota</path>
+      </linkdir>
+    </boardsupport>
+      <linkdir>
+      <board>Default</board>
       <toolchain>GNURX</toolchain>
       <series>RX600</series>
       <group>RX65N</group>
       <file>vendors/renesas/rx_mcu_boards/boards/rx65n-rsk-gcc/ports/pkcs11/iot_pkcs11_pal.c</file>
       <path>vendors/renesas/rx_mcu_boards/boards/rx65n-rsk-gcc/ports/pkcs11</path>
-    </linkdir>
-    <linkdir>
+      </linkdir>
+    <boardsupport>
+      <linkdir>
+      <board>RSKRX65N</board>
+      <board>RSKRX65N-2MB</board>
+      <toolchain>GNURX</toolchain>
+      <series>RX600</series>
+      <group>RX65N</group>
+      <file>vendors/renesas/rx_mcu_boards/boards/rx65n-rsk-gcc/ports/pkcs11/iot_pkcs11_pal.c</file>
+      <path>vendors/renesas/rx_mcu_boards/boards/rx65n-rsk-gcc/ports/pkcs11</path>
+      </linkdir>
+    </boardsupport>
+    <boardsupport>
+      <linkdir>
+        <toolchain>GNURX</toolchain>
+        <board>CloudKitRX65N</board>
+        <series>RX600</series>
+        <group>RX65N</group>
+        <file>vendors/renesas/rx_mcu_boards/boards/rx65n-cloud-kit-uart-sx-ulpgn-gcc/ports/pkcs11/iot_pkcs11_pal.c</file>
+        <path>vendors/renesas/rx_mcu_boards/boards/rx65n-cloud-kit-uart-sx-ulpgn-gcc/ports/pkcs11</path>
+      </linkdir>
+    </boardsupport>
+      <linkdir>
+      <board>Default</board>
       <toolchain>RXC</toolchain>
       <series>RX600</series>
       <group>RX65N</group>
       <file>vendors/renesas/rx_mcu_boards/boards/rx65n-rsk/ports/pkcs11/iot_pkcs11_pal.c</file>
       <path>vendors/renesas/rx_mcu_boards/boards/rx65n-rsk/ports/pkcs11</path>
-    </linkdir>
-    <linkdir>
+      </linkdir>
+    <boardsupport>
+      <linkdir>
+      <board>RSKRX65N</board>
+      <board>RSKRX65N-2MB</board>
+      <toolchain>RXC</toolchain>
+      <series>RX600</series>
+      <group>RX65N</group>
+      <file>vendors/renesas/rx_mcu_boards/boards/rx65n-rsk/ports/pkcs11/iot_pkcs11_pal.c</file>
+      <path>vendors/renesas/rx_mcu_boards/boards/rx65n-rsk/ports/pkcs11</path>
+      </linkdir>
+    </boardsupport>
+    <boardsupport>
+      <linkdir>
+        <toolchain>RXC</toolchain>
+        <board>CloudKitRX65N</board>
+        <series>RX600</series>
+        <group>RX65N</group>
+        <file>vendors/renesas/rx_mcu_boards/boards/rx65n-cloud-kit-uart-sx-ulpgn/ports/pkcs11/iot_pkcs11_pal.c</file>
+        <path>vendors/renesas/rx_mcu_boards/boards/rx65n-cloud-kit-uart-sx-ulpgn/ports/pkcs11</path>
+      </linkdir>
+    </boardsupport>
+      <linkdir>
+      <board>Default</board>
       <toolchain>GNURX</toolchain>
       <series>RX600</series>
       <group>RX65N</group>
       <file>vendors/renesas/rx_mcu_boards/boards/rx65n-rsk-gcc/ports/ota/aws_ota_pal.c</file>
       <path>vendors/renesas/rx_mcu_boards/boards/rx65n-rsk-gcc/ports/ota</path>
-    </linkdir>
-    <linkdir>
+      </linkdir>
+    <boardsupport>
+      <linkdir>
+      <board>RSKRX65N</board>
+      <board>RSKRX65N-2MB</board>
+      <toolchain>GNURX</toolchain>
+      <series>RX600</series>
+      <group>RX65N</group>
+      <file>vendors/renesas/rx_mcu_boards/boards/rx65n-rsk-gcc/ports/ota/aws_ota_pal.c</file>
+      <path>vendors/renesas/rx_mcu_boards/boards/rx65n-rsk-gcc/ports/ota</path>
+      </linkdir>
+    </boardsupport>
+    <boardsupport>
+      <linkdir>
+        <toolchain>GNURX</toolchain>
+        <board>CloudKitRX65N</board>
+        <series>RX600</series>
+        <group>RX65N</group>
+        <file>vendors/renesas/rx_mcu_boards/boards/rx65n-cloud-kit-uart-sx-ulpgn-gcc/ports/ota/aws_ota_pal.c</file>
+        <path>vendors/renesas/rx_mcu_boards/boards/rx65n-cloud-kit-uart-sx-ulpgn-gcc/ports/ota</path>
+      </linkdir>
+    </boardsupport>
+      <linkdir>
+      <board>Default</board>
       <toolchain>RXC</toolchain>
       <series>RX600</series>
       <group>RX65N</group>
       <file>vendors/renesas/rx_mcu_boards/boards/rx65n-rsk/ports/ota/aws_ota_pal.c</file>
       <path>vendors/renesas/rx_mcu_boards/boards/rx65n-rsk/ports/ota</path>
-    </linkdir>
-    <linkdir>
+      </linkdir>
+    <boardsupport>
+      <linkdir>
+      <board>RSKRX65N</board>
+      <board>RSKRX65N-2MB</board>
+      <toolchain>RXC</toolchain>
+      <series>RX600</series>
+      <group>RX65N</group>
+      <file>vendors/renesas/rx_mcu_boards/boards/rx65n-rsk/ports/ota/aws_ota_pal.c</file>
+      <path>vendors/renesas/rx_mcu_boards/boards/rx65n-rsk/ports/ota</path>
+      </linkdir>
+    </boardsupport>
+    <boardsupport>
+      <linkdir>
+        <toolchain>RXC</toolchain>
+        <board>CloudKitRX65N</board>
+        <series>RX600</series>
+        <group>RX65N</group>
+        <file>vendors/renesas/rx_mcu_boards/boards/rx65n-cloud-kit-uart-sx-ulpgn/ports/ota/aws_ota_pal.c</file>
+        <path>vendors/renesas/rx_mcu_boards/boards/rx65n-cloud-kit-uart-sx-ulpgn/ports/ota</path>
+      </linkdir>
+    </boardsupport>
+    <boardsupport>
+      <linkdir>
+      <board>CloudKitRX65N</board>
+        <toolchain>RXC</toolchain>
+        <file>vendors/renesas/rx_mcu_boards/boards/rx65n-cloud-kit-uart-sx-ulpgn/ports/secure_sockets/iot_secure_sockets.c</file>
+        <path>libraries/abstractions/secure_sockets/rx65n-cloud-kit-uart-sx-ulpgn</path>
+      </linkdir>
+    </boardsupport>
+    <boardsupport>
+      <linkdir>
+        <board>CloudKitRX65N</board>
+        <toolchain>GNURX</toolchain>
+        <file>vendors/renesas/rx_mcu_boards/boards/rx65n-cloud-kit-uart-sx-ulpgn-gcc/ports/secure_sockets/iot_secure_sockets.c</file>
+        <path>libraries/abstractions/secure_sockets/rx65n-cloud-kit-uart-sx-ulpgn-gcc</path>
+      </linkdir>
+    </boardsupport>
+    <boardsupport>
+      <linkdir>
+      <board>CloudKitRX65N</board>
+        <file>libraries/abstractions/wifi/include/iot_wifi.h</file>
+        <path>libraries/abstractions/wifi/include</path>
+      </linkdir>
+    </boardsupport>
+    <boardsupport>
+      <linkdir>
+      <board>CloudKitRX65N</board>
+        <toolchain>RXC</toolchain>
+        <file>vendors/renesas/rx_mcu_boards/boards/rx65n-cloud-kit-uart-sx-ulpgn/ports/wifi/iot_wifi.c</file>
+        <path>libraries/abstractions/wifi/rx65n-cloud-kit-uart-sx-ulpgn</path>
+      </linkdir>
+    </boardsupport>
+    <boardsupport>
+      <linkdir>
+      <board>CloudKitRX65N</board>
+        <toolchain>GNURX</toolchain>
+        <file>vendors/renesas/rx_mcu_boards/boards/rx65n-cloud-kit-uart-sx-ulpgn-gcc/ports/wifi/iot_wifi.c</file>
+        <path>libraries/abstractions/wifi/rx65n-cloud-kit-uart-sx-ulpgn-gcc</path>
+      </linkdir>
+    </boardsupport>
+      <linkdir>
+      <board>Default</board>
       <toolchain>GNURX</toolchain>
       <series>RX700</series>
       <group>RX71M</group>
       <file>vendors/renesas/rx_mcu_boards/boards/rx71m-rsk-gcc/ports/pkcs11/iot_pkcs11_pal.c</file>
       <path>vendors/renesas/rx_mcu_boards/boards/rx71m-rsk-gcc/ports/pkcs11</path>
-    </linkdir>
-    <linkdir>
+      </linkdir>
+    <boardsupport>
+      <linkdir>
+      <board>RSKRX71M</board>
+      <toolchain>GNURX</toolchain>
+      <series>RX700</series>
+      <group>RX71M</group>
+      <file>vendors/renesas/rx_mcu_boards/boards/rx71m-rsk-gcc/ports/pkcs11/iot_pkcs11_pal.c</file>
+      <path>vendors/renesas/rx_mcu_boards/boards/rx71m-rsk-gcc/ports/pkcs11</path>
+      </linkdir>
+    </boardsupport>
+      <linkdir>
+      <board>Default</board>
       <toolchain>RXC</toolchain>
       <series>RX700</series>
       <group>RX71M</group>
       <file>vendors/renesas/rx_mcu_boards/boards/rx71m-rsk/ports/pkcs11/iot_pkcs11_pal.c</file>
       <path>vendors/renesas/rx_mcu_boards/boards/rx71m-rsk/ports/pkcs11</path>
-    </linkdir>
-    <linkdir>
+      </linkdir>
+    <boardsupport>
+      <linkdir>
+      <board>RSKRX71M</board>
+      <toolchain>RXC</toolchain>
+      <series>RX700</series>
+      <group>RX71M</group>
+      <file>vendors/renesas/rx_mcu_boards/boards/rx71m-rsk/ports/pkcs11/iot_pkcs11_pal.c</file>
+      <path>vendors/renesas/rx_mcu_boards/boards/rx71m-rsk/ports/pkcs11</path>
+      </linkdir>
+    </boardsupport>
+      <linkdir>
+      <board>Default</board>
       <toolchain>GNURX</toolchain>
       <series>RX700</series>
       <group>RX71M</group>
       <file>vendors/renesas/rx_mcu_boards/boards/rx71m-rsk-gcc/ports/ota/aws_ota_pal.c</file>
       <path>vendors/renesas/rx_mcu_boards/boards/rx71m-rsk-gcc/ports/ota</path>
-    </linkdir>
-    <linkdir>
+      </linkdir>
+    <boardsupport>
+      <linkdir>
+      <board>RSKRX71M</board>
+      <toolchain>GNURX</toolchain>
+      <series>RX700</series>
+      <group>RX71M</group>
+      <file>vendors/renesas/rx_mcu_boards/boards/rx71m-rsk-gcc/ports/ota/aws_ota_pal.c</file>
+      <path>vendors/renesas/rx_mcu_boards/boards/rx71m-rsk-gcc/ports/ota</path>
+      </linkdir>
+    </boardsupport>
+      <linkdir>
+      <board>Default</board>
       <toolchain>RXC</toolchain>
       <series>RX700</series>
       <group>RX71M</group>
       <file>vendors/renesas/rx_mcu_boards/boards/rx71m-rsk/ports/ota/aws_ota_pal.c</file>
       <path>vendors/renesas/rx_mcu_boards/boards/rx71m-rsk/ports/ota</path>
-    </linkdir>
-    <linkdir>
+      </linkdir>
+    <boardsupport>
+      <linkdir>
+      <board>RSKRX71M</board>
+      <toolchain>RXC</toolchain>
+      <series>RX700</series>
+      <group>RX71M</group>
+      <file>vendors/renesas/rx_mcu_boards/boards/rx71m-rsk/ports/ota/aws_ota_pal.c</file>
+      <path>vendors/renesas/rx_mcu_boards/boards/rx71m-rsk/ports/ota</path>
+      </linkdir>
+    </boardsupport>
+      <linkdir>
+      <board>Default</board>
       <toolchain>GNURX</toolchain>
       <series>RX700</series>
       <group>RX72M</group>
       <file>vendors/renesas/rx_mcu_boards/boards/rx72m-rsk-gcc/ports/pkcs11/iot_pkcs11_pal.c</file>
       <path>vendors/renesas/rx_mcu_boards/boards/rx72m-rsk-gcc/ports/pkcs11</path>
-    </linkdir>
-    <linkdir>
+      </linkdir>
+    <boardsupport>
+      <linkdir>
+      <board>RSKRX72M</board>
+      <toolchain>GNURX</toolchain>
+      <series>RX700</series>
+      <group>RX72M</group>
+      <file>vendors/renesas/rx_mcu_boards/boards/rx72m-rsk-gcc/ports/pkcs11/iot_pkcs11_pal.c</file>
+      <path>vendors/renesas/rx_mcu_boards/boards/rx72m-rsk-gcc/ports/pkcs11</path>
+      </linkdir>
+    </boardsupport>
+      <linkdir>
+      <board>Default</board>
       <toolchain>RXC</toolchain>
       <series>RX700</series>
       <group>RX72M</group>
       <file>vendors/renesas/rx_mcu_boards/boards/rx72m-rsk/ports/pkcs11/iot_pkcs11_pal.c</file>
       <path>vendors/renesas/rx_mcu_boards/boards/rx72m-rsk/ports/pkcs11</path>
-    </linkdir>
-    <linkdir>
+      </linkdir>
+    <boardsupport>
+      <linkdir>
+      <board>RSKRX72M</board>
+      <toolchain>RXC</toolchain>
+      <series>RX700</series>
+      <group>RX72M</group>
+      <file>vendors/renesas/rx_mcu_boards/boards/rx72m-rsk/ports/pkcs11/iot_pkcs11_pal.c</file>
+      <path>vendors/renesas/rx_mcu_boards/boards/rx72m-rsk/ports/pkcs11</path>
+      </linkdir>
+    </boardsupport>
+      <linkdir>
+      <board>Default</board>
       <toolchain>GNURX</toolchain>
       <series>RX700</series>
       <group>RX72M</group>
       <file>vendors/renesas/rx_mcu_boards/boards/rx72m-rsk-gcc/ports/ota/aws_ota_pal.c</file>
       <path>vendors/renesas/rx_mcu_boards/boards/rx72m-rsk-gcc/ports/ota</path>
-    </linkdir>
-    <linkdir>
+      </linkdir>
+    <boardsupport>
+      <linkdir>
+      <board>RSKRX72M</board>
+      <toolchain>GNURX</toolchain>
+      <series>RX700</series>
+      <group>RX72M</group>
+      <file>vendors/renesas/rx_mcu_boards/boards/rx72m-rsk-gcc/ports/ota/aws_ota_pal.c</file>
+      <path>vendors/renesas/rx_mcu_boards/boards/rx72m-rsk-gcc/ports/ota</path>
+      </linkdir>
+    </boardsupport>
+      <linkdir>
+      <board>Default</board>
       <toolchain>RXC</toolchain>
       <series>RX700</series>
       <group>RX72M</group>
       <file>vendors/renesas/rx_mcu_boards/boards/rx72m-rsk/ports/ota/aws_ota_pal.c</file>
       <path>vendors/renesas/rx_mcu_boards/boards/rx72m-rsk/ports/ota</path>
-    </linkdir>
+      </linkdir>
+    <boardsupport>
+      <linkdir>
+      <board>RSKRX72M</board>
+      <toolchain>RXC</toolchain>
+      <series>RX700</series>
+      <group>RX72M</group>
+      <file>vendors/renesas/rx_mcu_boards/boards/rx72m-rsk/ports/ota/aws_ota_pal.c</file>
+      <path>vendors/renesas/rx_mcu_boards/boards/rx72m-rsk/ports/ota</path>
+      </linkdir>
+    </boardsupport>
+      <linkdir>
+      <board>Default</board>
+      <toolchain>GNURX</toolchain>
+      <series>RX700</series>
+      <group>RX72N</group>
+      <file>vendors/renesas/rx_mcu_boards/boards/rx72n-envision-kit-gcc/ports/pkcs11/iot_pkcs11_pal.c</file>
+      <path>vendors/renesas/rx_mcu_boards/boards/rx7n-rsk-gcc/ports/pkcs11</path>
+      </linkdir>
+    <boardsupport>
+      <linkdir>
+      <board>ENVISIONRX72N</board>
+      <toolchain>GNURX</toolchain>
+      <series>RX700</series>
+      <group>RX72N</group>
+      <file>vendors/renesas/rx_mcu_boards/boards/rx72n-envision-kit-gcc/ports/pkcs11/iot_pkcs11_pal.c</file>
+      <path>vendors/renesas/rx_mcu_boards/boards/rx7n-rsk-gcc/ports/pkcs11</path>
+      </linkdir>
+    </boardsupport>
+      <linkdir>
+      <board>Default</board>
+      <toolchain>RXC</toolchain>
+      <series>RX700</series>
+      <group>RX72N</group>
+      <file>vendors/renesas/rx_mcu_boards/boards/rx72n-envision-kit/ports/pkcs11/iot_pkcs11_pal.c</file>
+      <path>vendors/renesas/rx_mcu_boards/boards/rx72n-envision-kit/ports/pkcs11</path>
+      </linkdir>
+    <boardsupport>
+      <linkdir>
+      <board>ENVISIONRX72N</board>
+      <toolchain>RXC</toolchain>
+      <series>RX700</series>
+      <group>RX72N</group>
+      <file>vendors/renesas/rx_mcu_boards/boards/rx72n-envision-kit/ports/pkcs11/iot_pkcs11_pal.c</file>
+      <path>vendors/renesas/rx_mcu_boards/boards/rx72n-envision-kit/ports/pkcs11</path>
+      </linkdir>
+    </boardsupport>
+      <linkdir>
+      <board>Default</board>
+      <toolchain>GNURX</toolchain>
+      <series>RX700</series>
+      <group>RX72N</group>
+      <file>vendors/renesas/rx_mcu_boards/boards/rx72n-envision-kit-gcc/ports/ota/aws_ota_pal.c</file>
+      <path>vendors/renesas/rx_mcu_boards/boards/rx72n-envision-kit-gcc/ports/ota</path>
+      </linkdir>
+    <boardsupport>
+      <linkdir>
+      <board>ENVISIONRX72N</board>
+      <toolchain>GNURX</toolchain>
+      <series>RX700</series>
+      <group>RX72N</group>
+      <file>vendors/renesas/rx_mcu_boards/boards/rx72n-envision-kit-gcc/ports/ota/aws_ota_pal.c</file>
+      <path>vendors/renesas/rx_mcu_boards/boards/rx72n-envision-kit-gcc/ports/ota</path>
+      </linkdir>
+    </boardsupport>
+      <linkdir>
+      <board>Default</board>
+      <toolchain>RXC</toolchain>
+      <series>RX700</series>
+      <group>RX72N</group>
+      <file>vendors/renesas/rx_mcu_boards/boards/rx72n-envision-kit/ports/ota/aws_ota_pal.c</file>
+      <path>vendors/renesas/rx_mcu_boards/boards/rx72n-envision-kit/ports/ota</path>
+      </linkdir>
+    <boardsupport>
+      <linkdir>
+      <board>ENVISIONRX72N</board>
+      <toolchain>RXC</toolchain>
+      <series>RX700</series>
+      <group>RX72N</group>
+      <file>vendors/renesas/rx_mcu_boards/boards/rx72n-envision-kit/ports/ota/aws_ota_pal.c</file>
+      <path>vendors/renesas/rx_mcu_boards/boards/rx72n-envision-kit/ports/ota</path>
+      </linkdir>
+    </boardsupport>
     <!--RZA2M -->
     <linkdir>
       <toolchain>GNUARM</toolchain>
@@ -1728,6 +3399,7 @@
       <group>RX64M</group>
       <group>RX71M</group>
       <group>RX72M</group>
+      <group>RX72N</group>
       <path>vendors/renesas/configuration</path>
     </devicemdf>
     <devicemdf>
@@ -1737,6 +3409,7 @@
       <group>RX64M</group>
       <group>RX71M</group>
       <group>RX72M</group>
+      <group>RX72N</group>
       <path>vendors/renesas/configuration</path>
     </devicemdf>
     <devicemdf>
@@ -1745,6 +3418,114 @@
       <group>RZA2M</group>
       <path>vendors/renesas/configuration/rz/rza2m</path>
     </devicemdf>
+    <boardsupport>
+      <scfgtemplate>
+      <toolchain>RXC</toolchain>
+      <board>RSKRX64M</board>
+      <series>RX600</series>
+      <group>RX64M</group>
+      <path>vendors/renesas/configuration/RSKRX64M_scfg.ftl</path>
+      </scfgtemplate>
+    </boardsupport>
+    <boardsupport>
+      <scfgtemplate>
+      <toolchain>RXC</toolchain>
+      <board>RSKRX65N-2MB</board>
+      <series>RX600</series>
+      <group>RX65N</group>
+      <path>vendors/renesas/configuration/RSKRX65N_scfg.ftl</path>
+      </scfgtemplate>
+    </boardsupport>
+    <boardsupport>
+      <scfgtemplate>
+      <toolchain>RXC</toolchain>
+        <board>CloudKitRX65N</board>
+        <series>RX600</series>
+        <group>RX65N</group>
+        <path>vendors/renesas/configuration/CloudKitRX65N_scfg.ftl</path>
+      </scfgtemplate>
+    </boardsupport>
+    <boardsupport>
+      <scfgtemplate>
+      <toolchain>RXC</toolchain>
+      <board>RSKRX71M</board>
+      <series>RX700</series>
+      <group>RX71M</group>
+      <path>vendors/renesas/configuration/RSKRX71M_scfg.ftl</path>
+      </scfgtemplate>
+    </boardsupport>
+    <boardsupport>
+      <scfgtemplate>
+      <toolchain>RXC</toolchain>
+      <board>RSKRX72M</board>
+      <series>RX700</series>
+      <group>RX72M</group>
+      <path>vendors/renesas/configuration/RSKRX72M_scfg.ftl</path>
+      </scfgtemplate>
+    </boardsupport>
+    <boardsupport>
+      <scfgtemplate>
+      <toolchain>RXC</toolchain>
+      <board>ENVISIONRX72N</board>
+      <series>RX700</series>
+      <group>RX72N</group>
+      <path>vendors/renesas/configuration/EnvisionRX72N_scfg.ftl</path>
+      </scfgtemplate>
+    </boardsupport>
+    <boardsupport>
+      <scfgtemplate>
+      <toolchain>GNURX</toolchain>
+      <board>RSKRX64M</board>
+      <series>RX600</series>
+      <group>RX64M</group>
+      <path>vendors/renesas/configuration/RSKRX64M_scfg.ftl</path>
+      </scfgtemplate>
+    </boardsupport>
+    <boardsupport>
+      <scfgtemplate>
+      <toolchain>GNURX</toolchain>
+      <board>RSKRX65N-2MB</board>
+      <series>RX600</series>
+      <group>RX65N</group>
+      <path>vendors/renesas/configuration/RSKRX65N_scfg.ftl</path>
+      </scfgtemplate>
+    </boardsupport>
+    <boardsupport>
+      <scfgtemplate>
+      <toolchain>GNURX</toolchain>
+        <board>CloudKitRX65N</board>
+        <series>RX600</series>
+        <group>RX65N</group>
+        <path>vendors/renesas/configuration/CloudKitRX65N_scfg.ftl</path>
+      </scfgtemplate>
+    </boardsupport>
+    <boardsupport>
+      <scfgtemplate>
+      <toolchain>GNURX</toolchain>
+      <board>RSKRX71M</board>
+      <series>RX700</series>
+      <group>RX71M</group>
+      <path>vendors/renesas/configuration/RSKRX71M_scfg.ftl</path>
+      </scfgtemplate>
+    </boardsupport>
+    <boardsupport>
+      <scfgtemplate>
+      <toolchain>GNURX</toolchain>
+      <board>RSKRX72M</board>
+      <series>RX700</series>
+      <group>RX72M</group>
+      <path>vendors/renesas/configuration/RSKRX72M_scfg.ftl</path>
+      </scfgtemplate>
+    </boardsupport>
+    <boardsupport>
+      <scfgtemplate>
+      <toolchain>GNURX</toolchain>
+      <board>ENVISIONRX72N</board>
+      <series>RX700</series>
+      <group>RX72N</group>
+      <path>vendors/renesas/configuration/EnvisionRX72N_scfg.ftl</path>
+      </scfgtemplate>
+    </boardsupport>
     <scfgtemplate>
       <toolchain>RXC</toolchain>
       <series>RX600</series>
@@ -1753,6 +3534,7 @@
       <group>RX65N</group>
       <group>RX71M</group>
       <group>RX72M</group>
+      <group>RX72N</group>
       <path>vendors/renesas/configuration/rx_scfg.ftl</path>
     </scfgtemplate>
     <scfgtemplate>
@@ -1763,6 +3545,7 @@
       <group>RX65N</group>
       <group>RX71M</group>
       <group>RX72M</group>
+      <group>RX72N</group>
       <path>vendors/renesas/configuration/rx_scfg.ftl</path>
     </scfgtemplate>
     <scfgtemplate>

--- a/vendors/renesas/configuration/rx_scfg.ftl
+++ b/vendors/renesas/configuration/rx_scfg.ftl
@@ -18,19 +18,20 @@
 </tool>
 <tool id="SWComponent" version="1.0.0.0">
 <configuration inuse="true" name="r_bsp">
-<component display="r_bsp" id="r_bsp5.20" version="5.20"/>
+<component display="r_bsp" id="r_bsp5.50" version="5.50"/>
+<gridItem id="BSP_CFG_CODE_FLASH_BANK_MODE" selectedIndex="0"/>
 <source id="com.renesas.smc.tools.swcomponent.fit.source"/>
 </configuration>
 <configuration inuse="true" name="r_s12ad_rx">
-<component display="r_s12ad_rx" id="r_s12ad_rx4.00" version="4.00"></component>
+<component display="r_s12ad_rx" id="r_s12ad_rx4.50" version="4.50"></component>
 <source description="Components supporting Firmware Integration Technology" display="Firmware Integration Technology" id="com.renesas.smc.tools.swcomponent.fit.source"/>
 </configuration>
 <configuration inuse="true" name="r_flash_rx">
-<component display="r_flash_rx" id="r_flash_rx4.00" version="4.00"></component>
+<component display="r_flash_rx" id="r_flash_rx4.50" version="4.50"></component>
 <source description="Components supporting Firmware Integration Technology" display="Firmware Integration Technology" id="com.renesas.smc.tools.swcomponent.fit.source"/>
 </configuration>
 <configuration inuse="true" name="r_sci_rx">
-<component display="r_sci_rx" id="r_sci_rx3.00" version="3.00"></component>
+<component display="r_sci_rx" id="r_sci_rx3.40" version="3.40"></component>
 <source description="Components supporting Firmware Integration Technology" display="Firmware Integration Technology" id="com.renesas.smc.tools.swcomponent.fit.source"/>
 </configuration>
 <configuration inuse="true" name="r_byteq">
@@ -38,7 +39,7 @@
 <source description="Components supporting Firmware Integration Technology" display="Firmware Integration Technology" id="com.renesas.smc.tools.swcomponent.fit.source"/>
 </configuration>
 <configuration inuse="true" name="r_ether_rx">
-<component display="r_ether_rx" id="r_ether_rx1.16" version="1.16"></component>
+<component display="r_ether_rx" id="r_ether_rx1.20" version="1.20"></component>
 <source description="Components supporting Firmware Integration Technology" display="Firmware Integration Technology" id="com.renesas.smc.tools.swcomponent.fit.source"/>
 </configuration>
 <configuration inuse="true" name="FreeRTOS_Object">

--- a/vendors/renesas/rx_mcu_boards/boards/custom/aws_demos/src/smc_gen/r_pincfg/Pin.c
+++ b/vendors/renesas/rx_mcu_boards/boards/custom/aws_demos/src/smc_gen/r_pincfg/Pin.c
@@ -1,0 +1,150 @@
+/***********************************************************************************************************************
+* DISCLAIMER
+* This software is supplied by Renesas Electronics Corporation and is only intended for use with Renesas products.
+* No other uses are authorized. This software is owned by Renesas Electronics Corporation and is protected under all
+* applicable laws, including copyright laws. 
+* THIS SOFTWARE IS PROVIDED "AS IS" AND RENESAS MAKES NO WARRANTIES REGARDING THIS SOFTWARE, WHETHER EXPRESS, IMPLIED
+* OR STATUTORY, INCLUDING BUT NOT LIMITED TO WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NON-INFRINGEMENT.  ALL SUCH WARRANTIES ARE EXPRESSLY DISCLAIMED.TO THE MAXIMUM EXTENT PERMITTED NOT PROHIBITED BY
+* LAW, NEITHER RENESAS ELECTRONICS CORPORATION NOR ANY OF ITS AFFILIATED COMPANIES SHALL BE LIABLE FOR ANY DIRECT,
+* INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES FOR ANY REASON RELATED TO THIS SOFTWARE, EVEN IF RENESAS OR
+* ITS AFFILIATES HAVE BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+* Renesas reserves the right, without notice, to make changes to this software and to discontinue the availability 
+* of this software. By using this software, you agree to the additional terms and conditions found by accessing the 
+* following link:
+* http://www.renesas.com/disclaimer
+*
+* Copyright (C) 2018 Renesas Electronics Corporation. All rights reserved.
+***********************************************************************************************************************/
+
+/***********************************************************************************************************************
+* File Name    : Pin.c
+* Version      : 1.0.2
+* Device(s)    : R5F565NEDxFC
+* Description  : This file implements SMC pin code generation.
+* Creation Date: 2020-04-09
+***********************************************************************************************************************/
+
+/***********************************************************************************************************************
+Pragma directive
+***********************************************************************************************************************/
+/* Start user code for pragma. Do not edit comment generated here */
+/* End user code. Do not edit comment generated here */
+
+/***********************************************************************************************************************
+Includes
+***********************************************************************************************************************/
+#include "r_cg_macrodriver.h"
+/* Start user code for include. Do not edit comment generated here */
+#include "Pin.h"
+/* End user code. Do not edit comment generated here */
+#include "r_cg_userdefine.h"
+
+/***********************************************************************************************************************
+Global variables and functions
+***********************************************************************************************************************/
+/* Start user code for global. Do not edit comment generated here */
+/* End user code. Do not edit comment generated here */
+
+/***********************************************************************************************************************
+* Function Name: R_Pins_Create
+* Description  : This function initializes Smart Configurator pins
+* Arguments    : None
+* Return Value : None
+***********************************************************************************************************************/
+
+#warning "Please configure pin setting for FIT"
+
+void R_Pins_Create(void)
+{
+    R_BSP_RegisterProtectDisable(BSP_REG_PROTECT_MPC);
+
+    /* Set ET0_COL pin */
+    MPC.PC7PFS.BYTE = 0x11U;
+    PORTC.PMR.BYTE |= 0x80U;
+
+    /* Set ET0_CRS pin */
+    MPC.P83PFS.BYTE = 0x11U;
+    PORT8.PMR.BYTE |= 0x08U;
+
+    /* Set ET0_ERXD0 pin */
+    MPC.P75PFS.BYTE = 0x11U;
+    PORT7.PMR.BYTE |= 0x20U;
+
+    /* Set ET0_ERXD1 pin */
+    MPC.P74PFS.BYTE = 0x11U;
+    PORT7.PMR.BYTE |= 0x10U;
+
+    /* Set ET0_ERXD2 pin */
+    MPC.PC1PFS.BYTE = 0x11U;
+    PORTC.PMR.BYTE |= 0x02U;
+
+    /* Set ET0_ERXD3 pin */
+    MPC.PC0PFS.BYTE = 0x11U;
+    PORTC.PMR.BYTE |= 0x01U;
+
+    /* Set ET0_ETXD0 pin */
+    MPC.P81PFS.BYTE = 0x11U;
+    PORT8.PMR.BYTE |= 0x02U;
+
+    /* Set ET0_ETXD1 pin */
+    MPC.P82PFS.BYTE = 0x11U;
+    PORT8.PMR.BYTE |= 0x04U;
+
+    /* Set ET0_ETXD2 pin */
+    MPC.PC5PFS.BYTE = 0x11U;
+    PORTC.PMR.BYTE |= 0x20U;
+
+    /* Set ET0_ETXD3 pin */
+    MPC.PC6PFS.BYTE = 0x11U;
+    PORTC.PMR.BYTE |= 0x40U;
+
+    /* Set ET0_LINKSTA pin */
+    MPC.P34PFS.BYTE = 0x11U;
+    PORT3.PMR.BYTE |= 0x10U;
+
+    /* Set ET0_MDC pin */
+    MPC.P72PFS.BYTE = 0x11U;
+    PORT7.PMR.BYTE |= 0x04U;
+
+    /* Set ET0_MDIO pin */
+    MPC.P71PFS.BYTE = 0x11U;
+    PORT7.PMR.BYTE |= 0x02U;
+
+    /* Set ET0_RX_CLK pin */
+    MPC.P76PFS.BYTE = 0x11U;
+    PORT7.PMR.BYTE |= 0x40U;
+
+    /* Set ET0_RX_DV pin */
+    MPC.PC2PFS.BYTE = 0x11U;
+    PORTC.PMR.BYTE |= 0x04U;
+
+    /* Set ET0_RX_ER pin */
+    MPC.P77PFS.BYTE = 0x11U;
+    PORT7.PMR.BYTE |= 0x80U;
+
+    /* Set ET0_TX_CLK pin */
+    MPC.PC4PFS.BYTE = 0x11U;
+    PORTC.PMR.BYTE |= 0x10U;
+
+    /* Set ET0_TX_EN pin */
+    MPC.P80PFS.BYTE = 0x11U;
+    PORT8.PMR.BYTE |= 0x01U;
+
+    /* Set ET0_TX_ER pin */
+    MPC.PC3PFS.BYTE = 0x11U;
+    PORTC.PMR.BYTE |= 0x08U;
+
+    /* Set RXD8 pin */
+    MPC.PJ1PFS.BYTE = 0x0AU;
+    PORTJ.PMR.BYTE |= 0x02U;
+
+    /* Set TXD8 pin */
+    PORTJ.PODR.BYTE |= 0x04U;
+    MPC.PJ2PFS.BYTE = 0x0AU;
+    PORTJ.PDR.BYTE |= 0x04U;
+    // PORTJ.PMR.BIT.B2 = 1U; // Please set the PMR bit after TE bit is set to 1.
+
+    R_BSP_RegisterProtectEnable(BSP_REG_PROTECT_MPC);
+}   
+

--- a/vendors/renesas/rx_mcu_boards/boards/custom/aws_demos/src/smc_gen/r_pincfg/Pin.h
+++ b/vendors/renesas/rx_mcu_boards/boards/custom/aws_demos/src/smc_gen/r_pincfg/Pin.h
@@ -1,0 +1,50 @@
+/***********************************************************************************************************************
+* DISCLAIMER
+* This software is supplied by Renesas Electronics Corporation and is only intended for use with Renesas products.
+* No other uses are authorized. This software is owned by Renesas Electronics Corporation and is protected under all
+* applicable laws, including copyright laws. 
+* THIS SOFTWARE IS PROVIDED "AS IS" AND RENESAS MAKES NO WARRANTIES REGARDING THIS SOFTWARE, WHETHER EXPRESS, IMPLIED
+* OR STATUTORY, INCLUDING BUT NOT LIMITED TO WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NON-INFRINGEMENT.  ALL SUCH WARRANTIES ARE EXPRESSLY DISCLAIMED.TO THE MAXIMUM EXTENT PERMITTED NOT PROHIBITED BY
+* LAW, NEITHER RENESAS ELECTRONICS CORPORATION NOR ANY OF ITS AFFILIATED COMPANIES SHALL BE LIABLE FOR ANY DIRECT,
+* INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES FOR ANY REASON RELATED TO THIS SOFTWARE, EVEN IF RENESAS OR
+* ITS AFFILIATES HAVE BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+* Renesas reserves the right, without notice, to make changes to this software and to discontinue the availability 
+* of this software. By using this software, you agree to the additional terms and conditions found by accessing the 
+* following link:
+* http://www.renesas.com/disclaimer
+*
+* Copyright (C) 2018 Renesas Electronics Corporation. All rights reserved.
+***********************************************************************************************************************/
+
+/***********************************************************************************************************************
+* File Name    : Pin.h
+* Version      : 1.0.2
+* Device(s)    : R5F565NEDxFC
+* Description  : This file implements SMC pin code generation.
+* Creation Date: 2020-04-09
+***********************************************************************************************************************/
+
+#ifndef PIN_H
+#define PIN_H
+
+/***********************************************************************************************************************
+Macro definitions (Register bit)
+***********************************************************************************************************************/
+
+/***********************************************************************************************************************
+Macro definitions
+***********************************************************************************************************************/
+
+/***********************************************************************************************************************
+Typedef definitions
+***********************************************************************************************************************/
+
+/***********************************************************************************************************************
+Global functions
+***********************************************************************************************************************/
+void R_Pins_Create(void);
+/* Start user code for function. Do not edit comment generated here */
+/* End user code. Do not edit comment generated here */
+#endif
+

--- a/vendors/renesas/rx_mcu_boards/boards/custom/aws_demos/src/smc_gen/r_pincfg/r_ether_rx_pinset.c
+++ b/vendors/renesas/rx_mcu_boards/boards/custom/aws_demos/src/smc_gen/r_pincfg/r_ether_rx_pinset.c
@@ -1,0 +1,126 @@
+/***********************************************************************************************************************
+* DISCLAIMER
+* This software is supplied by Renesas Electronics Corporation and is only intended for use with Renesas products.
+* No other uses are authorized. This software is owned by Renesas Electronics Corporation and is protected under all
+* applicable laws, including copyright laws. 
+* THIS SOFTWARE IS PROVIDED "AS IS" AND RENESAS MAKES NO WARRANTIES REGARDING THIS SOFTWARE, WHETHER EXPRESS, IMPLIED
+* OR STATUTORY, INCLUDING BUT NOT LIMITED TO WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NON-INFRINGEMENT.  ALL SUCH WARRANTIES ARE EXPRESSLY DISCLAIMED.TO THE MAXIMUM EXTENT PERMITTED NOT PROHIBITED BY
+* LAW, NEITHER RENESAS ELECTRONICS CORPORATION NOR ANY OF ITS AFFILIATED COMPANIES SHALL BE LIABLE FOR ANY DIRECT,
+* INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES FOR ANY REASON RELATED TO THIS SOFTWARE, EVEN IF RENESAS OR
+* ITS AFFILIATES HAVE BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+* Renesas reserves the right, without notice, to make changes to this software and to discontinue the availability 
+* of this software. By using this software, you agree to the additional terms and conditions found by accessing the 
+* following link:
+* http://www.renesas.com/disclaimer
+*
+* Copyright (C) 2020 Renesas Electronics Corporation. All rights reserved.
+***********************************************************************************************************************/
+/***********************************************************************************************************************
+* File Name    : r_ether_rx_pinset.c
+* Version      : 1.0.2
+* Device(s)    : R5F565NEDxFC
+* Tool-Chain   : RXC toolchain
+* Description  : Setting of port and mpc registers
+* Creation Date: 2020-04-09
+***********************************************************************************************************************/
+
+/***********************************************************************************************************************
+Includes
+***********************************************************************************************************************/
+#include "r_ether_rx_pinset.h"
+#include "platform.h"
+
+/***********************************************************************************************************************
+Global variables and functions
+***********************************************************************************************************************/
+
+/***********************************************************************************************************************
+* Function Name: R_ETHER_PinSet_ETHERC0_MII
+* Description  : This function initializes pins for r_ether_rx module
+* Arguments    : none
+* Return Value : none
+***********************************************************************************************************************/
+void R_ETHER_PinSet_ETHERC0_MII()
+{
+    R_BSP_RegisterProtectDisable(BSP_REG_PROTECT_MPC);
+
+    /* Set ET0_TX_CLK pin */
+    MPC.PC4PFS.BYTE = 0x11U;
+    PORTC.PMR.BIT.B4 = 1U;
+
+    /* Set ET0_RX_CLK pin */
+    MPC.P76PFS.BYTE = 0x11U;
+    PORT7.PMR.BIT.B6 = 1U;
+
+    /* Set ET0_TX_EN pin */
+    MPC.P80PFS.BYTE = 0x11U;
+    PORT8.PMR.BIT.B0 = 1U;
+
+    /* Set ET0_ETXD3 pin */
+    MPC.PC6PFS.BYTE = 0x11U;
+    PORTC.PMR.BIT.B6 = 1U;
+
+    /* Set ET0_ETXD2 pin */
+    MPC.PC5PFS.BYTE = 0x11U;
+    PORTC.PMR.BIT.B5 = 1U;
+
+    /* Set ET0_ETXD1 pin */
+    MPC.P82PFS.BYTE = 0x11U;
+    PORT8.PMR.BIT.B2 = 1U;
+
+    /* Set ET0_ETXD0 pin */
+    MPC.P81PFS.BYTE = 0x11U;
+    PORT8.PMR.BIT.B1 = 1U;
+
+    /* Set ET0_TX_ER pin */
+    MPC.PC3PFS.BYTE = 0x11U;
+    PORTC.PMR.BIT.B3 = 1U;
+
+    /* Set ET0_RX_DV pin */
+    MPC.PC2PFS.BYTE = 0x11U;
+    PORTC.PMR.BIT.B2 = 1U;
+
+    /* Set ET0_ERXD3 pin */
+    MPC.PC0PFS.BYTE = 0x11U;
+    PORTC.PMR.BIT.B0 = 1U;
+
+    /* Set ET0_ERXD2 pin */
+    MPC.PC1PFS.BYTE = 0x11U;
+    PORTC.PMR.BIT.B1 = 1U;
+
+    /* Set ET0_ERXD1 pin */
+    MPC.P74PFS.BYTE = 0x11U;
+    PORT7.PMR.BIT.B4 = 1U;
+
+    /* Set ET0_ERXD0 pin */
+    MPC.P75PFS.BYTE = 0x11U;
+    PORT7.PMR.BIT.B5 = 1U;
+
+    /* Set ET0_RX_ER pin */
+    MPC.P77PFS.BYTE = 0x11U;
+    PORT7.PMR.BIT.B7 = 1U;
+
+    /* Set ET0_CRS pin */
+    MPC.P83PFS.BYTE = 0x11U;
+    PORT8.PMR.BIT.B3 = 1U;
+
+    /* Set ET0_COL pin */
+    MPC.PC7PFS.BYTE = 0x11U;
+    PORTC.PMR.BIT.B7 = 1U;
+
+    /* Set ET0_MDC pin */
+    MPC.P72PFS.BYTE = 0x11U;
+    PORT7.PMR.BIT.B2 = 1U;
+
+    /* Set ET0_MDIO pin */
+    MPC.P71PFS.BYTE = 0x11U;
+    PORT7.PMR.BIT.B1 = 1U;
+
+    /* Set ET0_LINKSTA pin */
+    MPC.P34PFS.BYTE = 0x11U;
+    PORT3.PMR.BIT.B4 = 1U;
+
+    R_BSP_RegisterProtectEnable(BSP_REG_PROTECT_MPC);
+}
+

--- a/vendors/renesas/rx_mcu_boards/boards/custom/aws_demos/src/smc_gen/r_pincfg/r_ether_rx_pinset.h
+++ b/vendors/renesas/rx_mcu_boards/boards/custom/aws_demos/src/smc_gen/r_pincfg/r_ether_rx_pinset.h
@@ -1,0 +1,41 @@
+/***********************************************************************************************************************
+* DISCLAIMER
+* This software is supplied by Renesas Electronics Corporation and is only intended for use with Renesas products.
+* No other uses are authorized. This software is owned by Renesas Electronics Corporation and is protected under all
+* applicable laws, including copyright laws. 
+* THIS SOFTWARE IS PROVIDED "AS IS" AND RENESAS MAKES NO WARRANTIES REGARDING THIS SOFTWARE, WHETHER EXPRESS, IMPLIED
+* OR STATUTORY, INCLUDING BUT NOT LIMITED TO WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NON-INFRINGEMENT.  ALL SUCH WARRANTIES ARE EXPRESSLY DISCLAIMED.TO THE MAXIMUM EXTENT PERMITTED NOT PROHIBITED BY
+* LAW, NEITHER RENESAS ELECTRONICS CORPORATION NOR ANY OF ITS AFFILIATED COMPANIES SHALL BE LIABLE FOR ANY DIRECT,
+* INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES FOR ANY REASON RELATED TO THIS SOFTWARE, EVEN IF RENESAS OR
+* ITS AFFILIATES HAVE BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+* Renesas reserves the right, without notice, to make changes to this software and to discontinue the availability 
+* of this software. By using this software, you agree to the additional terms and conditions found by accessing the 
+* following link:
+* http://www.renesas.com/disclaimer
+*
+* Copyright (C) 2020 Renesas Electronics Corporation. All rights reserved.
+***********************************************************************************************************************/
+/***********************************************************************************************************************
+* File Name    : r_ether_rx_pinset.h
+* Version      : 1.0.2
+* Device(s)    : R5F565NEDxFC
+* Tool-Chain   : RXC toolchain
+* Description  : Setting of port and mpc registers
+* Creation Date: 2020-04-09
+***********************************************************************************************************************/
+
+#ifndef R_ETHER_RX_H
+#define R_ETHER_RX_H
+
+/***********************************************************************************************************************
+Includes
+***********************************************************************************************************************/
+
+/***********************************************************************************************************************
+Global variables and functions
+***********************************************************************************************************************/
+
+void R_ETHER_PinSet_ETHERC0_MII();
+
+#endif

--- a/vendors/renesas/rx_mcu_boards/boards/custom/aws_demos/src/smc_gen/r_pincfg/r_pinset.h
+++ b/vendors/renesas/rx_mcu_boards/boards/custom/aws_demos/src/smc_gen/r_pincfg/r_pinset.h
@@ -1,0 +1,35 @@
+/***********************************************************************************************************************
+* DISCLAIMER
+* This software is supplied by Renesas Electronics Corporation and is only intended for use with Renesas products.
+* No other uses are authorized. This software is owned by Renesas Electronics Corporation and is protected under all
+* applicable laws, including copyright laws. 
+* THIS SOFTWARE IS PROVIDED "AS IS" AND RENESAS MAKES NO WARRANTIES REGARDING THIS SOFTWARE, WHETHER EXPRESS, IMPLIED
+* OR STATUTORY, INCLUDING BUT NOT LIMITED TO WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NON-INFRINGEMENT.  ALL SUCH WARRANTIES ARE EXPRESSLY DISCLAIMED.TO THE MAXIMUM EXTENT PERMITTED NOT PROHIBITED BY
+* LAW, NEITHER RENESAS ELECTRONICS CORPORATION NOR ANY OF ITS AFFILIATED COMPANIES SHALL BE LIABLE FOR ANY DIRECT,
+* INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES FOR ANY REASON RELATED TO THIS SOFTWARE, EVEN IF RENESAS OR
+* ITS AFFILIATES HAVE BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+* Renesas reserves the right, without notice, to make changes to this software and to discontinue the availability 
+* of this software. By using this software, you agree to the additional terms and conditions found by accessing the 
+* following link:
+* http://www.renesas.com/disclaimer
+*
+* Copyright (C) 2020 Renesas Electronics Corporation. All rights reserved.
+***********************************************************************************************************************/
+/***********************************************************************************************************************
+* File Name    : r_pinset.h.h
+* Version      : 1.0.1
+* Description  : Declares all pin code headers into a single file
+* Creation Date: 2020-04-09
+***********************************************************************************************************************/
+
+#ifndef R_PINSET_H
+#define R_PINSET_H
+
+/***********************************************************************************************************************
+Includes
+***********************************************************************************************************************/
+#include "r_ether_rx_pinset.h"
+#include "r_sci_rx_pinset.h"
+
+#endif /* R_PINSET_H */

--- a/vendors/renesas/rx_mcu_boards/boards/custom/aws_demos/src/smc_gen/r_pincfg/r_s12ad_rx_pinset.c
+++ b/vendors/renesas/rx_mcu_boards/boards/custom/aws_demos/src/smc_gen/r_pincfg/r_s12ad_rx_pinset.c
@@ -1,0 +1,60 @@
+/***********************************************************************************************************************
+* DISCLAIMER
+* This software is supplied by Renesas Electronics Corporation and is only intended for use with Renesas products.
+* No other uses are authorized. This software is owned by Renesas Electronics Corporation and is protected under all
+* applicable laws, including copyright laws. 
+* THIS SOFTWARE IS PROVIDED "AS IS" AND RENESAS MAKES NO WARRANTIES REGARDING THIS SOFTWARE, WHETHER EXPRESS, IMPLIED
+* OR STATUTORY, INCLUDING BUT NOT LIMITED TO WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NON-INFRINGEMENT.  ALL SUCH WARRANTIES ARE EXPRESSLY DISCLAIMED.TO THE MAXIMUM EXTENT PERMITTED NOT PROHIBITED BY
+* LAW, NEITHER RENESAS ELECTRONICS CORPORATION NOR ANY OF ITS AFFILIATED COMPANIES SHALL BE LIABLE FOR ANY DIRECT,
+* INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES FOR ANY REASON RELATED TO THIS SOFTWARE, EVEN IF RENESAS OR
+* ITS AFFILIATES HAVE BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+* Renesas reserves the right, without notice, to make changes to this software and to discontinue the availability 
+* of this software. By using this software, you agree to the additional terms and conditions found by accessing the 
+* following link:
+* http://www.renesas.com/disclaimer
+*
+* Copyright (C) 2020 Renesas Electronics Corporation. All rights reserved.
+***********************************************************************************************************************/
+/***********************************************************************************************************************
+* File Name    : r_s12ad_rx_pinset.c
+* Version      : 1.0.2
+* Device(s)    : R5F565NEDxFC
+* Tool-Chain   : RXC toolchain
+* Description  : Setting of port and mpc registers
+* Creation Date: 2020-04-09
+***********************************************************************************************************************/
+
+/***********************************************************************************************************************
+Includes
+***********************************************************************************************************************/
+#include "r_s12ad_rx_pinset.h"
+#include "platform.h"
+
+/***********************************************************************************************************************
+Global variables and functions
+***********************************************************************************************************************/
+
+/***********************************************************************************************************************
+* Function Name: R_ADC_PinSet_S12AD0
+* Description  : This function initializes pins for r_s12ad_rx module
+* Arguments    : none
+* Return Value : none
+***********************************************************************************************************************/
+void R_ADC_PinSet_S12AD0()
+{
+    R_BSP_RegisterProtectDisable(BSP_REG_PROTECT_MPC);
+
+    /* Set AN000 pin */
+    PORT4.PCR.BIT.B0 = 0U;
+    PORT4.PDR.BIT.B0 = 0U;
+    PORT4.PMR.BIT.B0 = 0U;
+    MPC.P40PFS.BYTE = 0x80U;
+
+    /* Set ADTRG0# pin */
+    MPC.P07PFS.BYTE = 0x09U;
+    PORT0.PMR.BIT.B7 = 1U;
+
+    R_BSP_RegisterProtectEnable(BSP_REG_PROTECT_MPC);
+}
+

--- a/vendors/renesas/rx_mcu_boards/boards/custom/aws_demos/src/smc_gen/r_pincfg/r_s12ad_rx_pinset.h
+++ b/vendors/renesas/rx_mcu_boards/boards/custom/aws_demos/src/smc_gen/r_pincfg/r_s12ad_rx_pinset.h
@@ -1,0 +1,41 @@
+/***********************************************************************************************************************
+* DISCLAIMER
+* This software is supplied by Renesas Electronics Corporation and is only intended for use with Renesas products.
+* No other uses are authorized. This software is owned by Renesas Electronics Corporation and is protected under all
+* applicable laws, including copyright laws. 
+* THIS SOFTWARE IS PROVIDED "AS IS" AND RENESAS MAKES NO WARRANTIES REGARDING THIS SOFTWARE, WHETHER EXPRESS, IMPLIED
+* OR STATUTORY, INCLUDING BUT NOT LIMITED TO WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NON-INFRINGEMENT.  ALL SUCH WARRANTIES ARE EXPRESSLY DISCLAIMED.TO THE MAXIMUM EXTENT PERMITTED NOT PROHIBITED BY
+* LAW, NEITHER RENESAS ELECTRONICS CORPORATION NOR ANY OF ITS AFFILIATED COMPANIES SHALL BE LIABLE FOR ANY DIRECT,
+* INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES FOR ANY REASON RELATED TO THIS SOFTWARE, EVEN IF RENESAS OR
+* ITS AFFILIATES HAVE BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+* Renesas reserves the right, without notice, to make changes to this software and to discontinue the availability 
+* of this software. By using this software, you agree to the additional terms and conditions found by accessing the 
+* following link:
+* http://www.renesas.com/disclaimer
+*
+* Copyright (C) 2020 Renesas Electronics Corporation. All rights reserved.
+***********************************************************************************************************************/
+/***********************************************************************************************************************
+* File Name    : r_s12ad_rx_pinset.h
+* Version      : 1.0.2
+* Device(s)    : R5F565NEDxFC
+* Tool-Chain   : RXC toolchain
+* Description  : Setting of port and mpc registers
+* Creation Date: 2020-04-09
+***********************************************************************************************************************/
+
+#ifndef R_S12AD_RX_H
+#define R_S12AD_RX_H
+
+/***********************************************************************************************************************
+Includes
+***********************************************************************************************************************/
+
+/***********************************************************************************************************************
+Global variables and functions
+***********************************************************************************************************************/
+
+void R_ADC_PinSet_S12AD0();
+
+#endif

--- a/vendors/renesas/rx_mcu_boards/boards/custom/aws_demos/src/smc_gen/r_pincfg/r_sci_rx_pinset.c
+++ b/vendors/renesas/rx_mcu_boards/boards/custom/aws_demos/src/smc_gen/r_pincfg/r_sci_rx_pinset.c
@@ -1,0 +1,73 @@
+/***********************************************************************************************************************
+* DISCLAIMER
+* This software is supplied by Renesas Electronics Corporation and is only intended for use with Renesas products.
+* No other uses are authorized. This software is owned by Renesas Electronics Corporation and is protected under all
+* applicable laws, including copyright laws. 
+* THIS SOFTWARE IS PROVIDED "AS IS" AND RENESAS MAKES NO WARRANTIES REGARDING THIS SOFTWARE, WHETHER EXPRESS, IMPLIED
+* OR STATUTORY, INCLUDING BUT NOT LIMITED TO WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NON-INFRINGEMENT.  ALL SUCH WARRANTIES ARE EXPRESSLY DISCLAIMED.TO THE MAXIMUM EXTENT PERMITTED NOT PROHIBITED BY
+* LAW, NEITHER RENESAS ELECTRONICS CORPORATION NOR ANY OF ITS AFFILIATED COMPANIES SHALL BE LIABLE FOR ANY DIRECT,
+* INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES FOR ANY REASON RELATED TO THIS SOFTWARE, EVEN IF RENESAS OR
+* ITS AFFILIATES HAVE BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+* Renesas reserves the right, without notice, to make changes to this software and to discontinue the availability 
+* of this software. By using this software, you agree to the additional terms and conditions found by accessing the 
+* following link:
+* http://www.renesas.com/disclaimer
+*
+* Copyright (C) 2020 Renesas Electronics Corporation. All rights reserved.
+***********************************************************************************************************************/
+/***********************************************************************************************************************
+* File Name    : r_sci_rx_pinset.c
+* Version      : 1.0.2
+* Device(s)    : R5F565NEDxFC
+* Tool-Chain   : RXC toolchain
+* Description  : Setting of port and mpc registers
+* Creation Date: 2020-04-09
+***********************************************************************************************************************/
+
+/***********************************************************************************************************************
+Includes
+***********************************************************************************************************************/
+#include "r_sci_rx_pinset.h"
+#include "platform.h"
+
+/***********************************************************************************************************************
+Global variables and functions
+***********************************************************************************************************************/
+
+/***********************************************************************************************************************
+* Function Name: R_SCI_PinSet_SCI8
+* Description  : This function initializes pins for r_sci_rx module
+* Arguments    : none
+* Return Value : none
+***********************************************************************************************************************/
+void R_SCI_PinSet_SCI2()
+{
+    R_BSP_RegisterProtectDisable(BSP_REG_PROTECT_MPC);
+
+    /* Set RXD2/SMISO2 pin */
+    MPC.P12PFS.BYTE = 0x0AU;
+    PORT1.PMR.BIT.B2 = 1U;
+
+    /* Set TXD2/SMOSI2 pin */
+    MPC.P13PFS.BYTE = 0x0AU;
+    PORT1.PMR.BIT.B3 = 1U;
+
+    R_BSP_RegisterProtectEnable(BSP_REG_PROTECT_MPC);
+}
+
+void R_SCI_PinSet_SCI8()
+{
+    R_BSP_RegisterProtectDisable(BSP_REG_PROTECT_MPC);
+
+    /* Set RXD8/SMISO8/SSCL8 pin */
+    MPC.PJ1PFS.BYTE = 0x0AU;
+    PORTJ.PMR.BIT.B1 = 1U;
+
+    /* Set TXD8/SMOSI8/SSDA8 pin */
+    MPC.PJ2PFS.BYTE = 0x0AU;
+    PORTJ.PMR.BIT.B2 = 1U;
+
+    R_BSP_RegisterProtectEnable(BSP_REG_PROTECT_MPC);
+}
+

--- a/vendors/renesas/rx_mcu_boards/boards/custom/aws_demos/src/smc_gen/r_pincfg/r_sci_rx_pinset.h
+++ b/vendors/renesas/rx_mcu_boards/boards/custom/aws_demos/src/smc_gen/r_pincfg/r_sci_rx_pinset.h
@@ -1,0 +1,41 @@
+/***********************************************************************************************************************
+* DISCLAIMER
+* This software is supplied by Renesas Electronics Corporation and is only intended for use with Renesas products.
+* No other uses are authorized. This software is owned by Renesas Electronics Corporation and is protected under all
+* applicable laws, including copyright laws. 
+* THIS SOFTWARE IS PROVIDED "AS IS" AND RENESAS MAKES NO WARRANTIES REGARDING THIS SOFTWARE, WHETHER EXPRESS, IMPLIED
+* OR STATUTORY, INCLUDING BUT NOT LIMITED TO WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NON-INFRINGEMENT.  ALL SUCH WARRANTIES ARE EXPRESSLY DISCLAIMED.TO THE MAXIMUM EXTENT PERMITTED NOT PROHIBITED BY
+* LAW, NEITHER RENESAS ELECTRONICS CORPORATION NOR ANY OF ITS AFFILIATED COMPANIES SHALL BE LIABLE FOR ANY DIRECT,
+* INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES FOR ANY REASON RELATED TO THIS SOFTWARE, EVEN IF RENESAS OR
+* ITS AFFILIATES HAVE BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+* Renesas reserves the right, without notice, to make changes to this software and to discontinue the availability 
+* of this software. By using this software, you agree to the additional terms and conditions found by accessing the 
+* following link:
+* http://www.renesas.com/disclaimer
+*
+* Copyright (C) 2020 Renesas Electronics Corporation. All rights reserved.
+***********************************************************************************************************************/
+/***********************************************************************************************************************
+* File Name    : r_sci_rx_pinset.h
+* Version      : 1.0.2
+* Device(s)    : R5F565NEDxFC
+* Tool-Chain   : RXC toolchain
+* Description  : Setting of port and mpc registers
+* Creation Date: 2020-04-09
+***********************************************************************************************************************/
+
+#ifndef R_SCI_RX_H
+#define R_SCI_RX_H
+
+/***********************************************************************************************************************
+Includes
+***********************************************************************************************************************/
+
+/***********************************************************************************************************************
+Global variables and functions
+***********************************************************************************************************************/
+
+void R_SCI_PinSet_SCI8();
+
+#endif


### PR DESCRIPTION
Update AFR project generation configuration files (for afr-v202002.00-rx-1.0.2 package)

Description
-----------
- Added <board> tag filter for project generation with supported board
- Added "custom" folder in "vendors/renesas/rx_mcu_boards/boards" for custom board project generation
- Added CloudKitRX65N_scfg.ftl for CloudKit RX65N project generation SC template


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.