### PR TITLE
Removed OTA dependencies for RX72N

### DIFF
--- a/vendors/renesas/configuration/afr-202002.00-rx-1.0.2.xml
+++ b/vendors/renesas/configuration/afr-202002.00-rx-1.0.2.xml
@@ -872,9 +872,34 @@
       <path>application_code/demos/include</path>
     </impdir>
     <impdir>
+          <board>Default</board>
+          <series>RX600</series>
+          <series>RX700</series>
+          <group>RX64M</group>
+          <group>RX65N</group>
+          <group>RX71M</group>
+          <group>RX72M</group>
       <file>demos/ota/aws_iot_ota_update_demo.c</file>
       <path>application_code/demos/ota</path>
     </impdir>
+    <boardsupport>
+      <impdir>
+          <board>RSKRX64M</board>
+          <board>RSKRX65N</board>
+          <board>RSKRX65N-2MB</board>
+          <board>RSKRX71M</board>
+          <board>RSKRX72M</board>
+          <board>CloudKitRX65N</board>
+          <series>RX600</series>
+          <series>RX700</series>
+          <group>RX64M</group>
+          <group>RX65N</group>
+          <group>RX71M</group>
+          <group>RX72M</group>
+      <file>demos/ota/aws_iot_ota_update_demo.c</file>
+      <path>application_code/demos/ota</path>
+      </impdir>
+    </boardsupport>
     <impdir>
       <file>demos/mqtt/iot_demo_mqtt.c</file>
       <path>application_code/demos/mqtt</path>
@@ -2519,11 +2544,44 @@
       <path>libraries/c_sdk/standard/serializer/src</path>
     </linkdir>
     <linkdir>
+          <board>Default</board>
+          <series>RX600</series>
+          <series>RX700</series>
+          <group>RX64M</group>
+          <group>RX65N</group>
+          <group>RX71M</group>
+          <group>RX72M</group>
       <file>libraries/freertos_plus/aws/ota/src/http/aws_iot_ota_http.c</file>
       <file>libraries/freertos_plus/aws/ota/src/http/aws_iot_ota_http.h</file>
       <path>libraries/freertos_plus/aws/ota/src/http</path>
     </linkdir>
+    <boardsupport>
+      <linkdir>
+          <board>RSKRX64M</board>
+          <board>RSKRX65N</board>
+          <board>RSKRX65N-2MB</board>
+          <board>RSKRX71M</board>
+          <board>RSKRX72M</board>
+          <board>CloudKitRX65N</board>
+          <series>RX600</series>
+          <series>RX700</series>
+          <group>RX64M</group>
+          <group>RX65N</group>
+          <group>RX71M</group>
+          <group>RX72M</group>
+      <file>libraries/freertos_plus/aws/ota/src/http/aws_iot_ota_http.c</file>
+      <file>libraries/freertos_plus/aws/ota/src/http/aws_iot_ota_http.h</file>
+      <path>libraries/freertos_plus/aws/ota/src/http</path>
+      </linkdir>
+    </boardsupport>
     <linkdir>
+          <board>Default</board>
+          <series>RX600</series>
+          <series>RX700</series>
+          <group>RX64M</group>
+          <group>RX65N</group>
+          <group>RX71M</group>
+          <group>RX72M</group>
       <file>libraries/freertos_plus/aws/ota/src/mqtt/aws_iot_ota_cbor.c</file>
       <file>libraries/freertos_plus/aws/ota/src/mqtt/aws_iot_ota_cbor.h</file>
       <file>libraries/freertos_plus/aws/ota/src/mqtt/aws_iot_ota_cbor_internal.h</file>
@@ -2531,12 +2589,67 @@
       <file>libraries/freertos_plus/aws/ota/src/mqtt/aws_iot_ota_mqtt.h</file>
       <path>libraries/freertos_plus/aws/ota/src/mqtt</path>
     </linkdir>
+    <boardsupport>
+      <linkdir>
+          <board>RSKRX64M</board>
+          <board>RSKRX65N</board>
+          <board>RSKRX65N-2MB</board>
+          <board>RSKRX71M</board>
+          <board>RSKRX72M</board>
+          <board>CloudKitRX65N</board>
+          <series>RX600</series>
+          <series>RX700</series>
+          <group>RX64M</group>
+          <group>RX65N</group>
+          <group>RX71M</group>
+          <group>RX72M</group>
+      <file>libraries/freertos_plus/aws/ota/src/mqtt/aws_iot_ota_cbor.c</file>
+      <file>libraries/freertos_plus/aws/ota/src/mqtt/aws_iot_ota_cbor.h</file>
+      <file>libraries/freertos_plus/aws/ota/src/mqtt/aws_iot_ota_cbor_internal.h</file>
+      <file>libraries/freertos_plus/aws/ota/src/mqtt/aws_iot_ota_mqtt.c</file>
+      <file>libraries/freertos_plus/aws/ota/src/mqtt/aws_iot_ota_mqtt.h</file>
+      <path>libraries/freertos_plus/aws/ota/src/mqtt</path>
+    </linkdir>
+    </boardsupport>
     <linkdir>
+          <board>Default</board>
+          <series>RX600</series>
+          <series>RX700</series>
+          <group>RX64M</group>
+          <group>RX65N</group>
+          <group>RX71M</group>
+          <group>RX72M</group>
       <file>libraries/freertos_plus/aws/ota/include/aws_iot_ota_agent.h</file>
       <file>libraries/freertos_plus/aws/ota/include/aws_iot_ota_types.h</file>
       <path>libraries/freertos_plus/aws/ota/include</path>
     </linkdir>
+    <boardsupport>
+      <linkdir>
+          <board>RSKRX64M</board>
+          <board>RSKRX65N</board>
+          <board>RSKRX65N-2MB</board>
+          <board>RSKRX71M</board>
+          <board>RSKRX72M</board>
+          <board>CloudKitRX65N</board>
+          <series>RX600</series>
+          <series>RX700</series>
+          <group>RX64M</group>
+          <group>RX65N</group>
+          <group>RX71M</group>
+          <group>RX72M</group>
+      <file>libraries/freertos_plus/aws/ota/include/aws_iot_ota_agent.h</file>
+      <file>libraries/freertos_plus/aws/ota/include/aws_iot_ota_types.h</file>
+      <path>libraries/freertos_plus/aws/ota/include</path>
+    </linkdir>
+    </boardsupport>
     <linkdir>
+          <board>Default</board>
+          <series>RX600</series>
+          <series>RX700</series>
+          <group>RX64M</group>
+          <group>RX65N</group>
+          <group>RX71M</group>
+          <group>RX72M</group>
       <file>libraries/freertos_plus/aws/ota/src/aws_iot_ota_agent_internal.h</file>
       <file>libraries/freertos_plus/aws/ota/src/aws_iot_ota_agent.c</file>
       <file>libraries/freertos_plus/aws/ota/src/aws_iot_ota_interface.c</file>
@@ -2544,6 +2657,28 @@
       <file>libraries/freertos_plus/aws/ota/src/aws_iot_ota_pal.h</file>
       <path>libraries/freertos_plus/aws/ota/src</path>
     </linkdir>
+    <boardsupport>
+      <linkdir>
+          <board>RSKRX64M</board>
+          <board>RSKRX65N</board>
+          <board>RSKRX65N-2MB</board>
+          <board>RSKRX71M</board>
+          <board>RSKRX72M</board>
+          <board>CloudKitRX65N</board>
+          <series>RX600</series>
+          <series>RX700</series>
+          <group>RX64M</group>
+          <group>RX65N</group>
+          <group>RX71M</group>
+          <group>RX72M</group>
+      <file>libraries/freertos_plus/aws/ota/src/aws_iot_ota_agent_internal.h</file>
+      <file>libraries/freertos_plus/aws/ota/src/aws_iot_ota_agent.c</file>
+      <file>libraries/freertos_plus/aws/ota/src/aws_iot_ota_interface.c</file>
+      <file>libraries/freertos_plus/aws/ota/src/aws_iot_ota_interface.h</file>
+      <file>libraries/freertos_plus/aws/ota/src/aws_iot_ota_pal.h</file>
+      <path>libraries/freertos_plus/aws/ota/src</path>
+    </linkdir>
+    </boardsupport>
     <linkdir>
       <file>libraries/freertos_plus/aws/greengrass/include/aws_ggd_config_defaults.h</file>
       <file>libraries/freertos_plus/aws/greengrass/include/aws_greengrass_discovery.h</file>
@@ -3305,42 +3440,6 @@
       <path>vendors/renesas/rx_mcu_boards/boards/rx72n-envision-kit/ports/pkcs11</path>
       </linkdir>
     </boardsupport>
-      <linkdir>
-      <board>Default</board>
-      <toolchain>GNURX</toolchain>
-      <series>RX700</series>
-      <group>RX72N</group>
-      <file>vendors/renesas/rx_mcu_boards/boards/rx72n-envision-kit-gcc/ports/ota/aws_ota_pal.c</file>
-      <path>vendors/renesas/rx_mcu_boards/boards/rx72n-envision-kit-gcc/ports/ota</path>
-      </linkdir>
-    <boardsupport>
-      <linkdir>
-      <board>ENVISIONRX72N</board>
-      <toolchain>GNURX</toolchain>
-      <series>RX700</series>
-      <group>RX72N</group>
-      <file>vendors/renesas/rx_mcu_boards/boards/rx72n-envision-kit-gcc/ports/ota/aws_ota_pal.c</file>
-      <path>vendors/renesas/rx_mcu_boards/boards/rx72n-envision-kit-gcc/ports/ota</path>
-      </linkdir>
-    </boardsupport>
-      <linkdir>
-      <board>Default</board>
-      <toolchain>RXC</toolchain>
-      <series>RX700</series>
-      <group>RX72N</group>
-      <file>vendors/renesas/rx_mcu_boards/boards/rx72n-envision-kit/ports/ota/aws_ota_pal.c</file>
-      <path>vendors/renesas/rx_mcu_boards/boards/rx72n-envision-kit/ports/ota</path>
-      </linkdir>
-    <boardsupport>
-      <linkdir>
-      <board>ENVISIONRX72N</board>
-      <toolchain>RXC</toolchain>
-      <series>RX700</series>
-      <group>RX72N</group>
-      <file>vendors/renesas/rx_mcu_boards/boards/rx72n-envision-kit/ports/ota/aws_ota_pal.c</file>
-      <path>vendors/renesas/rx_mcu_boards/boards/rx72n-envision-kit/ports/ota</path>
-      </linkdir>
-    </boardsupport>
     <!--RZA2M -->
     <linkdir>
       <toolchain>GNUARM</toolchain>
@@ -3528,6 +3627,7 @@
     </boardsupport>
     <scfgtemplate>
       <toolchain>RXC</toolchain>
+      <board>Default</board>
       <series>RX600</series>
       <series>RX700</series>
       <group>RX64M</group>
@@ -3539,6 +3639,7 @@
     </scfgtemplate>
     <scfgtemplate>
       <toolchain>GNURX</toolchain>
+      <board>Default</board>
       <series>RX600</series>
       <series>RX700</series>
       <group>RX64M</group>

--- a/vendors/renesas/configuration/rx_scfg.ftl
+++ b/vendors/renesas/configuration/rx_scfg.ftl
@@ -18,8 +18,9 @@
 </tool>
 <tool id="SWComponent" version="1.0.0.0">
 <configuration inuse="true" name="r_bsp">
-<component display="r_bsp" id="r_bsp5.50" version="5.50"/>
+<component display="r_bsp" id="r_bsp5.50" version="5.50">
 <gridItem id="BSP_CFG_CODE_FLASH_BANK_MODE" selectedIndex="0"/>
+</component>
 <source id="com.renesas.smc.tools.swcomponent.fit.source"/>
 </configuration>
 <configuration inuse="true" name="r_s12ad_rx">


### PR DESCRIPTION
… for RX72N projects.

- Updated r_bsp setting in rx_scfg.ftl for custom board PG

Removed OTA dependencies for RX72N

Description
-----------
- Added <board> tag for OTA files to avoid redundant OTA dependencies for RX72N projects.
- Updated r_bsp setting in rx_scfg.ftl for custom board PG


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.