### PR TITLE
Implemented feature to remove non-Renesas folders.

### DIFF
--- a/vendors/renesas/configuration/afr-202002.00-rx-1.0.3.xml
+++ b/vendors/renesas/configuration/afr-202002.00-rx-1.0.3.xml
@@ -2294,7 +2294,7 @@
         <board>Default</board>
         <series>RX700</series>
         <group>RX72N</group>
-        <folder>vendors/renesas/boards/rx_mcu_boards/rx72n-envision-kit-gcc/aws_demos/src/smc_gen/general</folder>
+        <folder>vendors/renesas/boards/rx_mcu_boards/rx72n-envision-kit/aws_demos/src/smc_gen/general</folder>
         <path>application_code/renesas_code/smc_gen/general</path>
     </impdir>
     <impdir>
@@ -2302,7 +2302,7 @@
         <board>Default</board>
         <series>RX700</series>
         <group>RX72N</group>
-        <folder>vendors/renesas/boards/rx_mcu_boards/rx72n-envision-kit-gcc/aws_demos/src/smc_gen/r_config</folder>
+        <folder>vendors/renesas/boards/rx_mcu_boards/rx72n-envision-kit/aws_demos/src/smc_gen/r_config</folder>
         <path>application_code/renesas_code/smc_gen/r_config</path>
     </impdir>
     <impdir>
@@ -3930,5 +3930,6 @@
       <key>SMC_GENERATED_LOC</key>
       <path>${PROJECT_LOC}/application_code/renesas_code/smc_gen</path>
     </linkedresource>
+    <settingfile>vendors/renesas/configuration/renesas_only.xml</settingfile>
   </package>
 </refinfo>

--- a/vendors/renesas/configuration/renesas_only.xml
+++ b/vendors/renesas/configuration/renesas_only.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<setting>
+  <remove>
+    <path>vendors/cypress</path>
+    <path>vendors/espressif</path>
+    <path>vendors/infineon</path>
+    <path>vendors/marvell</path>
+	<path>vendors/mediatek</path>
+	<path>vendors/microchip</path>
+	<path>vendors/nordic</path>
+	<path>vendors/nuvoton</path>
+	<path>vendors/nxp</path>
+	<path>vendors/pc</path>
+	<path>vendors/st</path>
+	<path>vendors/ti</path>
+	<path>vendors/xilinx</path>
+	
+    <path>projects/cypress</path>
+    <path>projects/espressif</path>
+    <path>projects/infineon</path>
+    <path>projects/marvell</path>
+	<path>projects/mediatek</path>
+	<path>projects/microchip</path>
+	<path>projects/nordic</path>
+	<path>projects/nuvoton</path>
+	<path>projects/nxp</path>
+	<path>projects/pc</path>
+	<path>projects/st</path>
+	<path>projects/ti</path>
+	<path>projects/xilinx</path>
+  </remove>
+</setting>


### PR DESCRIPTION
AFR package downloaded with e2s will only contain Renesas folder in 'vendor' & 'project' folder.